### PR TITLE
Add Version utils

### DIFF
--- a/src/main/scala/za/co/absa/commons/version/Component.scala
+++ b/src/main/scala/za/co/absa/commons/version/Component.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.version
+
+/**
+  * Represents a one component of a version.
+  * E.g. for the version string "1.foo.42" the components would be "1", "foo" and "42".
+  */
+sealed trait Component extends Ordered[Component] {
+  final override def compare(that: Component): Int = {
+    val c = comparator
+    if (c isDefinedAt that) c(that)
+    else -(that compare this)
+  }
+
+  def comparator: PartialFunction[Component, Int]
+}
+
+object Component {
+  def apply(s: String): Component =
+    if (s.forall(_.isDigit)) NumericComponent(s.toInt)
+    else StringComponent(s)
+}
+
+/**
+  * An empty component that is less that any other component as long as the other component claims the opposite.
+  */
+case object EmptyComponent extends Component {
+  override def comparator: PartialFunction[Component, Int] = {
+    case EmptyComponent => 0
+  }
+}
+
+/**
+  * A numeric component.
+  * Compares naturally to itself.
+  */
+case class NumericComponent(x: Int) extends Component {
+  override def comparator: PartialFunction[Component, Int] = {
+    case EmptyComponent => +1
+    case NumericComponent(y) => x compare y
+  }
+}
+
+/**
+  * A string component.
+  * String components are compared lexicographically and have higher precedence than numeric components.
+  */
+case class StringComponent(s: String) extends Component {
+  override def comparator: PartialFunction[Component, Int] = {
+    case EmptyComponent => +1
+    case NumericComponent(_) => +1
+    case StringComponent(t) => s compare t
+  }
+}
+
+/**
+  * A pre-release component [SemVer]
+  *
+  * Precedence for a pre-release component is determined by comparing each identifier from left to right
+  * until a difference is found as follows:
+  * - identifiers consisting of only digits are compared numerically
+  * - identifiers with letters or hyphens are compared lexically in ASCII sort order
+  * - numeric identifiers always have lower precedence than non-numeric identifiers
+  * - a larger set of fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal
+  *
+  * Example: alpha < alpha.1 < alpha.beta < beta < beta.2 < beta.11 < rc.1
+  *
+  * A pre-release component have a lower precedence than an empty component.
+  *
+  * @see https://semver.org/spec/v2.0.0.html#spec-item-9
+  * @param identifiers build identifiers
+  */
+case class PreReleaseComponent(identifiers: Component*) extends Component {
+  require(identifiers.nonEmpty)
+
+  override def comparator: PartialFunction[Component, Int] = {
+    case EmptyComponent => -1
+    case NumericComponent(_) => -1
+    case StringComponent(_) => -1
+    case that: PreReleaseComponent =>
+      Version(this.identifiers: _*) compare Version(that.identifiers: _*)
+  }
+}
+
+/**
+  * A build metadata component [SemVer]
+  * It behaves as {{EmptyComponent}} when comparing to other components, i.e. it doesn't count.
+  *
+  * @see https://semver.org/spec/v2.0.0.html#spec-item-10
+  * @param identifiers build identifiers
+  */
+case class BuildMetadataComponent(identifiers: Component*) extends Component {
+  require(identifiers.nonEmpty)
+
+  override def comparator: PartialFunction[Component, Int] = {
+    case other: Component => EmptyComponent compare other
+  }
+}

--- a/src/main/scala/za/co/absa/commons/version/Version.scala
+++ b/src/main/scala/za/co/absa/commons/version/Version.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.version
+
+import za.co.absa.commons.version.impl.{SemVer20Impl, SimpleVersionImpl}
+
+case class Version(components: Component*) extends Ordered[Version] {
+  override def compare(that: Version): Int = components
+    .zipAll(that.components, EmptyComponent, EmptyComponent)
+    .map({ case (xi, yi) => xi compare yi })
+    .filterNot(0.==)
+    .headOption
+    .getOrElse(0)
+}
+
+object Version extends SimpleVersionImpl with SemVer20Impl {
+
+  implicit class VersionStringInterpolator(val sc: StringContext) extends AnyVal {
+
+    def ver(args: Any*): Version = Version.asSimple(sc.s(args: _*))
+
+    def semver(args: Any*): Version = Version.asSemVer(sc.s(args: _*))
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/version/impl/SemVer20Impl.scala
+++ b/src/main/scala/za/co/absa/commons/version/impl/SemVer20Impl.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.version.impl
+
+import za.co.absa.commons.version._
+import za.co.absa.commons.version.impl.SemVer20Impl._
+
+import scala.util.matching.Regex
+
+/**
+  * Semantic Versioning 2.0 implementation
+  *
+  * @see https://semver.org/spec/v2.0.0.html
+  */
+trait SemVer20Impl {
+
+  def asSemVer(verStr: String): Version = verStr match {
+    case SemVerRegexp(major, minor, patch, preRelease, buildMeta) =>
+      val mainComponents = Seq(
+        NumericComponent(major.toInt),
+        NumericComponent(minor.toInt),
+        NumericComponent(patch.toInt))
+
+      val optionalComponents = Seq(
+        Option(preRelease).map(s => PreReleaseComponent(parseIdentifiers(s): _*)),
+        Option(buildMeta).map(s => BuildMetadataComponent(parseIdentifiers(s): _*))
+      ).flatten
+
+      Version(mainComponents ++ optionalComponents: _*)
+
+    case _ => throw new IllegalArgumentException(s"$verStr does not correspond to the SemVer 2.0 spec")
+  }
+
+  private def parseIdentifiers(str: String): Seq[Component] =
+    str.split('.') map Component.apply
+}
+
+object SemVer20Impl {
+  private val SemVerRegexp: Regex = ("^" +
+    "(0|[1-9]\\d*)\\." +
+    "(0|[1-9]\\d*)\\." +
+    "(0|[1-9]\\d*)" +
+    "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?" +
+    "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?" +
+    "$").r
+}

--- a/src/main/scala/za/co/absa/commons/version/impl/SimpleVersionImpl.scala
+++ b/src/main/scala/za/co/absa/commons/version/impl/SimpleVersionImpl.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.version.impl
+
+import za.co.absa.commons.version.{Component, Version}
+
+trait SimpleVersionImpl {
+  def asSimple(verStr: String): Version =
+    Version(verStr.split('.') map Component.apply: _*)
+}

--- a/src/test/scala/za/co/absa/commons/version/SemanticVersionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/version/SemanticVersionSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.version
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.version.Version._
+
+import scala.Ordering.Implicits._
+import scala.util.Random
+
+class SemanticVersionSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "Version parser"
+
+  it should "parse semantic version" in {
+    Version.asSemVer("1.22.333") should be(Version(
+      NumericComponent(1),
+      NumericComponent(22),
+      NumericComponent(333),
+    ))
+    Version.asSemVer("1.22.333-SNAPSHOT.77") should be(Version(
+      NumericComponent(1),
+      NumericComponent(22),
+      NumericComponent(333),
+      PreReleaseComponent(
+        StringComponent("SNAPSHOT"),
+        NumericComponent(77),
+      ),
+    ))
+    Version.asSemVer("1.22.333+foo.bar") should be(Version(
+      NumericComponent(1),
+      NumericComponent(22),
+      NumericComponent(333),
+      BuildMetadataComponent(
+        StringComponent("foo"),
+        StringComponent("bar"),
+      ),
+    ))
+    Version.asSemVer("1.22.333-SNAPSHOT.77+foo.bar") should be(Version(
+      NumericComponent(1),
+      NumericComponent(22),
+      NumericComponent(333),
+      PreReleaseComponent(
+        StringComponent("SNAPSHOT"),
+        NumericComponent(77),
+      ),
+      BuildMetadataComponent(
+        StringComponent("foo"),
+        StringComponent("bar"),
+      ),
+    ))
+  }
+
+  it should "not parse" in {
+    intercept[IllegalArgumentException](Version.asSemVer(""))
+    intercept[IllegalArgumentException](Version.asSemVer("1"))
+    intercept[IllegalArgumentException](Version.asSemVer("1.1"))
+    intercept[IllegalArgumentException](Version.asSemVer("1.1.0."))
+    intercept[IllegalArgumentException](Version.asSemVer("1.1.01"))
+    intercept[IllegalArgumentException](Version.asSemVer("1.1.1,"))
+    intercept[IllegalArgumentException](Version.asSemVer("1.1.1+@"))
+    intercept[IllegalArgumentException](Version.asSemVer("1.1.1-$"))
+    intercept[IllegalArgumentException](Version.asSemVer("1.1.1-"))
+    intercept[IllegalArgumentException](Version.asSemVer("a.b.c"))
+  }
+
+  behavior of "Version ordering"
+
+  it should "compare" in {
+    (semver"0.0.0" < semver"0.0.1") should be(true)
+    (semver"0.0.0" < semver"0.1.0") should be(true)
+    (semver"0.0.0" < semver"1.0.0") should be(true)
+    (semver"1.2.3" < semver"3.2.1") should be(true)
+    (semver"1.1.1-beta" < semver"1.1.1") should be(true)
+    (semver"1.1.1+meta" equiv semver"1.1.1") should be(true)
+    (semver"1.1.1-beta+meta" equiv semver"1.1.1-beta") should be(true)
+    (semver"1.1.1-beta" < semver"1.1.1-beta.1") should be(true)
+    (semver"1.1.1-beta2" > semver"1.1.1-beta.1") should be(true)
+    (semver"1.1.1-beta2" > semver"1.1.1-beta11") should be(true)
+    (semver"1.1.1-beta.2" < semver"1.1.1-beta.11") should be(true)
+    (semver"1.1.1-beta.1" < semver"1.1.1-beta.a") should be(true)
+    (semver"1.1.1-beta.1" < semver"1.1.1-beta.1a") should be(true)
+    (semver"1.1.1-beta.a" < semver"1.1.1-beta.b") should be(true)
+    (semver"1.1.1-B" < semver"1.1.1-b") should be(true)
+  }
+
+  it should "sort" in {
+    val versions = Seq(
+      semver"0.0.0+meta",
+      semver"0.0.1",
+      semver"0.0.11",
+      semver"0.1.1-alpha+m.e.t.a",
+      semver"0.1.1-beta",
+      semver"0.1.1-beta.2",
+      semver"0.1.1-beta.11",
+      semver"0.1.1-beta11",
+      semver"0.1.1-beta2",
+      semver"0.1.1",
+    )
+    Random.shuffle(versions).sorted should equal(versions)
+  }
+}

--- a/src/test/scala/za/co/absa/commons/version/SemanticVersionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/version/SemanticVersionSpec.scala
@@ -31,7 +31,7 @@ class SemanticVersionSpec extends AnyFlatSpec with Matchers {
     Version.asSemVer("1.22.333") should be(Version(
       NumericComponent(1),
       NumericComponent(22),
-      NumericComponent(333),
+      NumericComponent(333)
     ))
     Version.asSemVer("1.22.333-SNAPSHOT.77") should be(Version(
       NumericComponent(1),
@@ -39,8 +39,7 @@ class SemanticVersionSpec extends AnyFlatSpec with Matchers {
       NumericComponent(333),
       PreReleaseComponent(
         StringComponent("SNAPSHOT"),
-        NumericComponent(77),
-      ),
+        NumericComponent(77))
     ))
     Version.asSemVer("1.22.333+foo.bar") should be(Version(
       NumericComponent(1),
@@ -48,8 +47,7 @@ class SemanticVersionSpec extends AnyFlatSpec with Matchers {
       NumericComponent(333),
       BuildMetadataComponent(
         StringComponent("foo"),
-        StringComponent("bar"),
-      ),
+        StringComponent("bar"))
     ))
     Version.asSemVer("1.22.333-SNAPSHOT.77+foo.bar") should be(Version(
       NumericComponent(1),
@@ -57,12 +55,10 @@ class SemanticVersionSpec extends AnyFlatSpec with Matchers {
       NumericComponent(333),
       PreReleaseComponent(
         StringComponent("SNAPSHOT"),
-        NumericComponent(77),
-      ),
+        NumericComponent(77)),
       BuildMetadataComponent(
         StringComponent("foo"),
-        StringComponent("bar"),
-      ),
+        StringComponent("bar"))
     ))
   }
 
@@ -110,7 +106,7 @@ class SemanticVersionSpec extends AnyFlatSpec with Matchers {
       semver"0.1.1-beta.11",
       semver"0.1.1-beta11",
       semver"0.1.1-beta2",
-      semver"0.1.1",
+      semver"0.1.1"
     )
     Random.shuffle(versions).sorted should equal(versions)
   }

--- a/src/test/scala/za/co/absa/commons/version/SimpleVersionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/version/SimpleVersionSpec.scala
@@ -32,8 +32,7 @@ class SimpleVersionSpec extends AnyFlatSpec with Matchers {
       NumericComponent(1),
       StringComponent("two"),
       NumericComponent(33),
-      StringComponent("forty-two"),
-    ))
+      StringComponent("forty-two")))
   }
 
   it should "not parse" in {
@@ -63,7 +62,7 @@ class SimpleVersionSpec extends AnyFlatSpec with Matchers {
       ver"1.21",
       ver"1.21.9999",
       ver"1.22.0.1",
-      ver"1.111",
+      ver"1.111"
     )
     Random.shuffle(versions).sorted should equal(versions)
   }

--- a/src/test/scala/za/co/absa/commons/version/SimpleVersionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/version/SimpleVersionSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.version
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.version.Version._
+
+import scala.Ordering.Implicits._
+import scala.util.Random
+
+class SimpleVersionSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "Version parser"
+
+  it should "parse simple version" in {
+    Version.asSimple("1.two.33.forty-two") should be(Version(
+      NumericComponent(1),
+      StringComponent("two"),
+      NumericComponent(33),
+      StringComponent("forty-two"),
+    ))
+  }
+
+  it should "not parse" in {
+    intercept[IllegalArgumentException](Version.asSimple(""))
+  }
+
+  behavior of "Version ordering"
+
+  it should "compare" in {
+    (ver"1.2" equiv ver"01.002") should be(true)
+    (ver"0" < ver"0.0.0") should be(true)
+    (ver"1.1" < ver"1.1.0") should be(true)
+    (ver"1.22" > ver"0.22") should be(true)
+    (ver"1.22" > ver"1.21") should be(true)
+    (ver"1.22" > ver"1.9") should be(true)
+    (ver"1.22" > ver"1.9.9999") should be(true)
+    (ver"1.22" > ver"1.21.9999") should be(true)
+    (ver"1.22" < ver"1.22.0.1") should be(true)
+    (ver"1.22" < ver"1.111") should be(true)
+  }
+
+  it should "sort" in {
+    val versions = Seq(
+      ver"0.22",
+      ver"1.9",
+      ver"1.9.9999",
+      ver"1.21",
+      ver"1.21.9999",
+      ver"1.22.0.1",
+      ver"1.111",
+    )
+    Random.shuffle(versions).sorted should equal(versions)
+  }
+}

--- a/src/test/scala/za/co/absa/commons/version/VersionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/version/VersionSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.version
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.version.Version._
+
+class VersionSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "VersionStringInterpolator"
+
+  it should "parse versions" in {
+    ver"1.${2}.3-4" should be(Version(
+      NumericComponent(1),
+      NumericComponent(2),
+      StringComponent("3-4")
+    ))
+
+    semver"1.${2}.3-4" should be(Version(
+      NumericComponent(1),
+      NumericComponent(2),
+      NumericComponent(3),
+      PreReleaseComponent(NumericComponent(4))
+    ))
+  }
+}


### PR DESCRIPTION
A simple utility that parses version strings.
It supports SemVer 2.0 as well as a simple dot-separated version format.
Can be used to compare the versions, for instance when implementing version predicates.

Example:

```scala
require(Version.asSimple(SPARK_VERSION) > ver"2.4")
```
or
```scala
require(Version.asSemVer(SomeLibVersion) > semver"1.2.3-beta.2")
```