### PR TITLE
commons #17 fix of BuildInfo singleton

### DIFF
--- a/src/main/scala/za/co/absa/commons/buildinfo/BuildInfo.scala
+++ b/src/main/scala/za/co/absa/commons/buildinfo/BuildInfo.scala
@@ -57,7 +57,7 @@ abstract class BuildInfo(
   resourcePrefix: String = BuildInfoConst.DefaultResourcePrefix,
   propMapping: PropMapping = PropMapping.Default) {
 
-  val BuildProps: ImmutableProperties = {
+  lazy val BuildProps: ImmutableProperties = {
     val resourceName = s"$resourcePrefix.properties"
     val stream =
       this.getClass.getResource(s"$resourceName")
@@ -68,6 +68,6 @@ abstract class BuildInfo(
     using(stream)(ImmutableProperties.fromStream)
   }
 
-  val Version: String = BuildProps.getProperty(propMapping.version)
-  val Timestamp: String = BuildProps.getProperty(propMapping.timestamp)
+  lazy val Version: String = BuildProps.getProperty(propMapping.version)
+  lazy val Timestamp: String = BuildProps.getProperty(propMapping.timestamp)
 }


### PR DESCRIPTION
So I had a name conflict when using the default `BuildInfo` because one of libraries was using build.properties as well and the file was loaded instead of my properties. So I created my own singleton: 
```scala
object SplineBuildInfo extends BuildInfo("/spline-build")
```
But that caused error in different part of the project. BuildInfo object was still created even though I never touched it and it was searching for build.properties and failed.

At the end I found out that the default Scala parameters are actually (In bytecode/java) stored in the companion object. Therefore, when I call a constructor of a class and don't provide all parameters the companion object will be instantiated and the default parameter is loaded from there.
