### PR TITLE
commons #27 + #37 - Fixing binary incompatibilities in Json4s SerDe adapter

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -34,6 +34,5 @@ mvn clean
 
 cross_build 2.11
 cross_build 2.12
-cross_build 2.13
 
 mvn scala-cross-build:restore-version

--- a/src/main/scala/za/co/absa/commons/json/DefaultJacksonJsonSerDe.scala
+++ b/src/main/scala/za/co/absa/commons/json/DefaultJacksonJsonSerDe.scala
@@ -19,8 +19,6 @@ package za.co.absa.commons.json
 import org.json4s.jackson
 import za.co.absa.commons.json.format.DefaultFormatsBuilder
 
-object DefaultJacksonJsonSerDe extends DefaultJacksonJsonSerDe
-
 trait DefaultJacksonJsonSerDe
   extends AbstractJsonSerDe
     with jackson.JsonMethods

--- a/src/main/scala/za/co/absa/commons/json/format/JavaTypesSupport.scala
+++ b/src/main/scala/za/co/absa/commons/json/format/JavaTypesSupport.scala
@@ -16,9 +16,12 @@
 
 package za.co.absa.commons.json.format
 
-import org.json4s.Formats
 import org.json4s.ext.JavaTypesSerializers
+import org.json4s.{Formats, Serializer}
 
 trait JavaTypesSupport extends FormatsBuilder {
-  abstract override protected def formats: Formats = super.formats ++ JavaTypesSerializers.all
+  abstract override protected def formats: Formats = {
+    // we can't use `Formats.++` here because of https://github.com/AbsaOSS/commons/issues/27#issuecomment-700953553
+    (JavaTypesSerializers.all: Seq[Serializer[_]]).foldLeft(super.formats)(_ + _)
+  }
 }


### PR DESCRIPTION
Fixes #27 

Tested by https://github.com/wajda/absa-commons-json4s-test in all combinations of Scala 2.11, 2.12 and Json4s 3.2, 3.5, 3.6.

The fix was avoiding using `Formats++` and replacing it with `Formats.+` and folding. 