### PR TITLE
commons #8 extractFieldValue() should extract from Scala specific fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,36 +84,41 @@ conf.getRequiredXXX(...)
 ### Basics
 ##### Get direct sub-types of a sealed type
 ```scala
-directSubClassesOf[Food] // == Seq(classOf[Vegetables], classOf[Meat], classOf[Fish])
+ReflectionUtils.directSubClassesOf[Food] // == Seq(classOf[Vegetables], classOf[Meat], classOf[Fish])
 ```
 ##### Get `object` instances extending a sealed type
 ```scala
-objectsOf[Currency] // == Seq(classOf[EUR], classOf[USD], classOf[CZK])
+ReflectionUtils.objectsOf[Currency] // == Seq(classOf[EUR], classOf[USD], classOf[CZK])
 ```
 ##### Get `object` instance by it's full type name (similar to `Class.forName(...)`, but for objects)
 ```scala
-objectForName[MySingleton]("com.example.MySingleton") // == MySingleton
+ReflectionUtils.objectForName[MySingleton]("com.example.MySingleton") // == MySingleton
 ```
 ##### Get private field value of an arbitrary class. (a typed variant of `field.get(o).asInstanceOf[T]`)
 ```scala
-extractFieldValue[Int](foo, "bar")
-
-// or if the field `bar` is declared in one of the superclasses of `foo` (e.g. `Doh`),
-// and you want to save some CPU time by avoiding reflexive lookup in the hierarchy.
-extractFieldValue[Doh, Int](foo, "bar")
+ReflectionUtils.extractFieldValue[Int](foo, "bar")
+// or if you know a type where the field is declared
+ReflectionUtils.extractFieldValue[Doh, Int](foo, "bar")
 ```
 ##### Extract object properties as a key-value map
 ```scala
 case class Person(name: String, age: Int, sex: Sex)
 val aPerson = Person("Alex", 41, Male)
 
-extractProperties(aPerson) // == Map("name" -> "Alex, "age" -> 42, "sex" -> Male)
+ReflectionUtils.extractProperties(aPerson) // == Map("name" -> "Alex, "age" -> 42, "sex" -> Male)
 ```
 ##### Extract a case class argument default value (if exists)
 ```scala
 case class Button(title: String, isPressed = false)
-caseClassCtorArgDefaultValue[Int](classOf[Button], "name") // == None
-caseClassCtorArgDefaultValue[Int](classOf[Button], "isPressed") // == Some(false)
+ReflectionUtils.caseClassCtorArgDefaultValue[Int](classOf[Button], "name") // == None
+ReflectionUtils.caseClassCtorArgDefaultValue[Int](classOf[Button], "isPressed") // == Some(false)
+```
+
+##### Get all interfaces/traits of a given class including inherited ones
+```scala
+ReflectionUtils.ReflectionUtils.allInterfacesOf[A]
+// or
+ReflectionUtils.ReflectionUtils.allInterfacesOf(aClass)
 ```
 
 ### Enumeration macros

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -53,6 +54,8 @@
         <scm.connection>scm:git:git://github.com/AbsaOSS/commons.git</scm.connection>
         <scm.developerConnection>scm:git:ssh://github.com/AbsaOSS/commons.git</scm.developerConnection>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <json4s.version>3.5.5</json4s.version>
 

--- a/src/main/scala/za/co/absa/commons/reflect/ReflectionUtils.scala
+++ b/src/main/scala/za/co/absa/commons/reflect/ReflectionUtils.scala
@@ -150,6 +150,12 @@ object ReflectionUtils {
     extractFieldValue[AnyRef, T](o, fieldName)(ClassTag(o.getClass))
   }
 
+  /**
+    * Return all interfaces that the given class implements included inherited ones
+    *
+    * @param c a class
+    * @return
+    */
   def allInterfacesOf(c: Class[_]): Set[Class[_]] = {
     @tailrec
     def collect(ifs: Set[Class[_]], cs: Iterable[Class[_]]): Set[Class[_]] =
@@ -158,12 +164,21 @@ object ReflectionUtils {
         val c0 = cs.head
         val cN = cs.tail
         val ifsUpd = if (c0.isInterface) ifs + c0 else ifs
-        val csUpd = cN.toSet ++ (c0.getInterfaces filterNot ifsUpd)
+        val csUpd = cN.toSet ++ (c0.getInterfaces filterNot ifsUpd) ++ Option(c0.getSuperclass)
         collect(ifsUpd, csUpd)
       }
 
-    collect(Set.empty, c.getInterfaces)
+    collect(Set.empty, Seq(c))
   }
+
+  /**
+    * Same as {{{allInterfacesOf(aClass)}}}
+    *
+    * @tparam A a class type
+    * @return
+    */
+  def allInterfacesOf[A <: AnyRef : ClassTag]: Set[Class[_]] =
+    allInterfacesOf(implicitly[ClassTag[A]].runtimeClass)
 
   /**
     * Extract object properties as key-value pairs.

--- a/src/main/scala/za/co/absa/commons/reflect/ReflectionUtils.scala
+++ b/src/main/scala/za/co/absa/commons/reflect/ReflectionUtils.scala
@@ -118,12 +118,12 @@ object ReflectionUtils {
       val maybeValue =
         foundMembers.headOption
           .map(m => {
-            val im = rootMirror.reflect(o)
+            val im = mirror.reflect(o)
             if (m.isMethod) im.reflectMethod(m.asMethod).apply()
             else im.reflectField(m.asTerm).get
           })
           .orElse {
-            // Certain Scala compiler generated fields aren't return by `TypeApi.members` (e.g. `bitmap$0`).
+            // Sometimes certain Scala compiler generated fields aren't return by `TypeApi.members`.
             // Trying Java reflection.
             c.getDeclaredFields.collectFirst {
               case f if f.getName == fieldName =>

--- a/src/main/scala/za/co/absa/commons/reflect/ReflectionUtils.scala
+++ b/src/main/scala/za/co/absa/commons/reflect/ReflectionUtils.scala
@@ -188,17 +188,17 @@ object ReflectionUtils {
     */
   def allInterfacesOf(c: Class[_]): Set[Class[_]] = {
     @tailrec
-    def collect(ifs: Set[Class[_]], cs: Iterable[Class[_]]): Set[Class[_]] =
+    def collect(ifs: Set[Class[_]], cs: Set[Class[_]]): Set[Class[_]] =
       if (cs.isEmpty) ifs
       else {
         val c0 = cs.head
         val cN = cs.tail
         val ifsUpd = if (c0.isInterface) ifs + c0 else ifs
-        val csUpd = cN.toSet ++ (c0.getInterfaces filterNot ifsUpd) ++ Option(c0.getSuperclass)
+        val csUpd = cN ++ (c0.getInterfaces filterNot ifsUpd) ++ Option(c0.getSuperclass)
         collect(ifsUpd, csUpd)
       }
 
-    collect(Set.empty, Seq(c))
+    collect(Set.empty, Set(c))
   }
 
   /**

--- a/src/test/java/za/co/absa/commons/reflection/CyclicAnnotationExample.java
+++ b/src/test/java/za/co/absa/commons/reflection/CyclicAnnotationExample.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.reflection;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@CyclicAnnotationExample.CyclicAnnotation
+public class CyclicAnnotationExample {
+    private CyclicAnnotationExample() {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface CyclicAnnotation {
+    }
+}

--- a/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
@@ -140,6 +140,35 @@ class ReflectionUtilsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     ReflectionUtils.caseClassCtorArgDefaultValue[Int](classOf[Foo], "x") should be(None)
     ReflectionUtils.caseClassCtorArgDefaultValue[Int](classOf[Foo], "y") should be(Some(42))
   }
+
+  behavior of "allInterfacesOf()"
+
+  it should "return all interfaces that the given class implements included inherited ones" in {
+    trait T1
+    trait T2 extends T1
+    trait T3 extends T2
+    trait T4 extends T3 with T1
+
+    trait TX
+    trait TY
+    trait TZ
+
+    abstract class A extends T4 with TX
+    class B extends A with T1 with TY with TZ
+
+    val expectedSet = Set(
+      classOf[T1],
+      classOf[T2],
+      classOf[T3],
+      classOf[T4],
+      classOf[TX],
+      classOf[TY],
+      classOf[TZ]
+    )
+
+    ReflectionUtils.allInterfacesOf[B] should equal(expectedSet)
+    ReflectionUtils.allInterfacesOf(classOf[B]) should equal(expectedSet)
+  }
 }
 
 object ReflectionUtilsSpec {

--- a/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
@@ -90,16 +90,21 @@ class ReflectionUtilsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   }
 
   //noinspection ScalaUnusedSymbol
-  it should "extract from a lazy val" in {
+  it should "extract from a lazy val of inner classes" in {
     trait T {
-      lazy val z: Int = 42
+      private lazy val z: Int = 42
     }
     object O extends T {
-      lazy val zz: Seq[Nothing] = Seq.empty
+      private lazy val zz: Seq[Nothing] = Seq.empty
     }
     ReflectionUtils.extractFieldValue[Int](O, "z") should equal(42)
     ReflectionUtils.extractFieldValue[Seq[_]](O, "zz") should equal(Seq.empty)
     ReflectionUtils.extractFieldValue[Int](O, "bitmap$0") should equal(0x3)
+  }
+
+  it should "extract from a lazy val of outer classes" in {
+    ReflectionUtils.extractFieldValue[Boolean](Lazy, "z") should be(42)
+    ReflectionUtils.extractFieldValue[Boolean](Lazy, "bitmap$0") should be(true)
   }
 
   behavior of "ModuleClassSymbolExtractor"
@@ -199,6 +204,10 @@ object ReflectionUtilsSpec {
 
   class Bar(val a: String, b: Double) {
     def methodUsingFields: String = a + b.toString
+  }
+
+  object Lazy {
+    lazy val z = 42
   }
 
 }

--- a/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.commons.reflect
 
+import org.apache.hadoop.classification.InterfaceAudience
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -105,6 +106,15 @@ class ReflectionUtilsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
   it should "extract from a lazy val of outer classes" in {
     ReflectionUtils.extractFieldValue[Boolean](Lazy, "z") should be(42)
     ReflectionUtils.extractFieldValue[Boolean](Lazy, "bitmap$0") should be(true)
+  }
+
+  // A workaround for https://github.com/scala/bug/issues/12190
+  it should "fallback to Java reflection when Scala one fails" in {
+    @InterfaceAudience.Public
+    object Foo {
+      val x = 42
+    }
+    ReflectionUtils.extractFieldValue[Boolean](Foo, "x") should be(Foo.x)
   }
 
   behavior of "ModuleClassSymbolExtractor"

--- a/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
@@ -59,11 +59,6 @@ class ReflectionUtilsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     ReflectionUtils.extractFieldValue[Array[Char]]("foo", "value") should equal("foo".toCharArray)
   }
 
-  it should "blah" in {
-    case class X(y: Int)
-    ReflectionUtils.extractFieldValue[Int](X(7), "y") should equal(7)
-  }
-
   it should "return values of compiler generated private fields" in {
     val bar = new Bar("Pi", 3.14)
     ReflectionUtils.extractFieldValue[String](bar, "a") shouldEqual "Pi"
@@ -92,6 +87,19 @@ class ReflectionUtilsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     ReflectionUtils.extractFieldValue[Boolean](MyObject, "z") should be(true)
     ReflectionUtils.extractFieldValue[Boolean](new MyClass, "z") should be(true)
     ReflectionUtils.extractFieldValue[MyClass, Boolean](new MyClass, "z") should be(true)
+  }
+
+  //noinspection ScalaUnusedSymbol
+  it should "extract from a lazy val" in {
+    trait T {
+      lazy val z: Int = 42
+    }
+    object O extends T {
+      lazy val zz: Seq[Nothing] = Seq.empty
+    }
+    ReflectionUtils.extractFieldValue[Int](O, "z") should equal(42)
+    ReflectionUtils.extractFieldValue[Seq[_]](O, "zz") should equal(Seq.empty)
+    ReflectionUtils.extractFieldValue[Int](O, "bitmap$0") should equal(0x3)
   }
 
   behavior of "ModuleClassSymbolExtractor"


### PR DESCRIPTION
fixes #8 

This PR addresses Java/Scala reflection interoperability issue that is caused by expanded field names generated by certain Scala constructs, lambdas etc.

See unit tests