### PR TITLE
Collection implicits: + TraversableOnce.distinctBy(f)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ val arr: Array[_] = ???
 iter.fetchToArray(arr, 7, 42) // returns a number of actually copied items
 ```
 
+```scala
+import CollectionImplicits._
+
+// Get distinct elements by only comparing certain property(-es)
+val xs = Seq(
+   Foo(x = 1, ...), // A
+   Foo(x = 2, ...), // B
+   Foo(x = 1, ...), // C
+   Foo(x = 2, ...), // D
+   Foo(x = 3, ...), // E
+)
+xs.distinctBy(_.x) // returns elements A, B, E
+```
+
 # Abstract Converters
 A simple stackable `Converter` trait with a simple memoized wrapper.
 ### Usage 

--- a/src/test/scala/za/co/absa/commons/lang/CollectionImplicitsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/CollectionImplicitsSpec.scala
@@ -16,10 +16,14 @@
 
 package za.co.absa.commons.lang
 
+import org.mockito.Mockito
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class CollectionImplicitsSpec extends AnyFunSpec with Matchers {
+import scala.collection.mutable
+
+class CollectionImplicitsSpec extends AnyFunSpec with Matchers with MockitoSugar {
 
   import CollectionImplicits._
 
@@ -98,4 +102,56 @@ class CollectionImplicitsSpec extends AnyFunSpec with Matchers {
 
   }
 
+  describe("TraversableOnceOps") {
+    describe("distinctBy()") {
+
+      it("should do nothing on empty immutable collections") {
+        val dummyFn = mock[Unit => _]
+        Seq.empty[Unit].distinctBy(dummyFn) should be theSameInstanceAs Seq.empty
+        Mockito.verifyNoInteractions(dummyFn)
+      }
+
+      it("should create a new instance of empty mutable collections") {
+        val dummyFn = mock[Unit => _]
+        val originalCol = mutable.Seq.empty[Unit]
+        val distinctCol = originalCol.distinctBy(dummyFn)
+
+        distinctCol should not(be theSameInstanceAs originalCol)
+        distinctCol should have length 0
+        Mockito.verifyNoInteractions(dummyFn)
+      }
+
+      it("should return the same collection type as it was called on") {
+        // immutable
+        Seq(1, 2).distinctBy(identity) should be(a[Seq[_]])
+        List(1, 2).distinctBy(identity) should be(a[List[_]])
+        Vector(1, 2).distinctBy(identity) should be(a[Vector[_]])
+        Set(1, 2).distinctBy(identity) should be(a[Set[_]])
+        // mutable
+        Array(1, 2).distinctBy(identity) should be(a[Array[_]])
+        mutable.Seq(1, 2).distinctBy(identity) should be(a[mutable.Seq[_]])
+        mutable.ListBuffer(1, 2).distinctBy(identity) should be(a[mutable.ListBuffer[_]])
+        mutable.HashSet(1, 2).distinctBy(identity) should be(a[mutable.HashSet[_]])
+      }
+
+      it("should remove entries with duplicated projection") {
+        val abcde: Seq[(String, Int)] = Seq(
+          "a" -> 1,
+          "b" -> 2,
+          "c" -> 2,
+          "d" -> 3,
+          "e" -> 1
+        )
+
+        val abd = abcde.distinctBy { case (_, i) => i }
+
+        abd should be(a[Seq[_]])
+        abd should contain theSameElementsInOrderAs Seq(
+          "a" -> 1,
+          "b" -> 2,
+          "d" -> 3
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adds `distinctBy(f)` extension methods to collections. 

Similar to `distinct`, but instead of comparing elements directly it compares the values obtained by applying the provided projection function `f` on the elements.

It's logically equivalent to doing stable grouping by `f` followed by selecting the first value of each key.