### PR TITLE
Graph utils: topological sorting of a generic graph-node-like collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ val arr: Array[_] = ???
 iter.fetchToArray(arr, 7, 42) // returns a number of actually copied items
 ```
 
+# Graph Utils
+
+### Topological sorting (DAG only)
+```scala
+val myNodes: Seq[MyNode] = ??? // an arbitrary sequence of objects that can represent graph nodes 
+
+// import extension methods
+import za.co.absa.commons.graph.GraphImplicits._
+
+val sortedNodes = myNodes.sortedTopologicallyBy(_.id, _.refIds) // arguments are functions that return a self ID and outbound IDs for every node in the collection 
+
+// ... or using implicit `DAGNodeIDMapping` instance instead of explicitly passing mapping functions as arguments
+
+implicit object MyNodeIdMapping extends DAGNodeIdMapping[MyNode, NodeId] {
+   override def currentId(n: MyNode): NodeId = ???
+   override def outboundIds(n: MyNode): Seq[NodeId] = ???
+}
+
+val sortedNodes = myNodes.sortedTopologically()
+```
+
 # Abstract Converters
 A simple stackable `Converter` trait with a simple memoized wrapper.
 ### Usage 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ val sortedNodes = myNodes.sortedTopologicallyBy(_.id, _.refIds) // arguments are
 // ... or using implicit `DAGNodeIDMapping` instance instead of explicitly passing mapping functions as arguments
 
 implicit object MyNodeIdMapping extends DAGNodeIdMapping[MyNode, NodeId] {
-   override def currentId(n: MyNode): NodeId = ???
-   override def outboundIds(n: MyNode): Seq[NodeId] = ???
+   override def selfId(n: MyNode): NodeId = ???
+   override def refIds(n: MyNode): Traversable[NodeId] = ???
 }
 
 val sortedNodes = myNodes.sortedTopologically()

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,12 @@
             <version>2.6.7</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.scala-graph</groupId>
+            <artifactId>graph-core_${scala.binary.version}</artifactId>
+            <version>1.12.5</version>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test scope dependencies -->
 

--- a/src/main/scala/za/co/absa/commons/graph/GraphImplicits.scala
+++ b/src/main/scala/za/co/absa/commons/graph/GraphImplicits.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.graph
+
+import scalax.collection.Graph
+import scalax.collection.GraphEdge.DiEdge
+import scalax.collection.GraphPredef.EdgeAssoc
+
+import scala.collection.generic.CanBuildFrom
+import scala.language.higherKinds
+
+object GraphImplicits {
+
+  trait DAGNodeIdMapping[Node, Id] {
+    def currentId(n: Node): Id
+    def outboundIds(n: Node): Traversable[Id]
+  }
+
+  implicit class DAGNodeTraversableOps[Node, M[X] <: Seq[X]](val xs: M[Node]) extends AnyVal {
+
+    def sortedTopologicallyBy[Id](
+      currentIdFn: Node => Id,
+      outboundIdsFn: Node => Traversable[Id],
+      reverse: Boolean = false
+    )(implicit cbf: CanBuildFrom[M[Node], Node, M[Node]]): M[Node] = {
+      implicit val nav: DAGNodeIdMapping[Node, Id] = new DAGNodeIdMapping[Node, Id] {
+
+        override def currentId(n: Node): Id = currentIdFn(n)
+
+        override def outboundIds(n: Node): Traversable[Id] = outboundIdsFn(n)
+      }
+
+      sortedTopologically(reverse)
+    }
+
+    def sortedTopologically[Id](reverse: Boolean = false)(implicit nav: DAGNodeIdMapping[Node, Id], cbf: CanBuildFrom[M[Node], Node, M[Node]]): M[Node] =
+      if (xs.size < 2) xs
+      else {
+        val itemById = xs.map(op => nav.currentId(op) -> op).toMap
+
+        val createEdge: (Node, Id) => DiEdge[Node] =
+          if (reverse)
+            (item, nextId) => itemById(nextId) ~> item
+          else
+            (item, nextId) => item ~> itemById(nextId)
+
+        val edges: Traversable[DiEdge[Node]] =
+          for {
+            item <- xs
+            nextId <- nav.outboundIds(item)
+          } yield createEdge(item, nextId)
+
+        val sortResult = Graph
+          .from(
+            edges = edges,
+            nodes = xs)
+          .topologicalSort
+
+        sortResult match {
+          case Right(res) =>
+            val b = cbf(xs)
+            b ++= res.toOuter
+            b.result()
+          case Left(cycleNode) =>
+            throw new IllegalArgumentException(s"Expected DAG but a cycle was detected on the node: $cycleNode")
+        }
+      }
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/graph/AbstractGraphImplicits_SortedTopologicallySpec.scala
+++ b/src/test/scala/za/co/absa/commons/graph/AbstractGraphImplicits_SortedTopologicallySpec.scala
@@ -21,6 +21,8 @@ import org.scalatest.matchers._
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.commons.graph.AbstractGraphImplicits_SortedTopologicallySpec._
 
+import scala.collection.mutable.ListBuffer
+
 abstract class AbstractGraphImplicits_SortedTopologicallySpec(
   topologicalSortMethodName: String,
   executeTopologicalSortMethod: Seq[TestNode] => Seq[TestNode]
@@ -31,7 +33,7 @@ abstract class AbstractGraphImplicits_SortedTopologicallySpec(
 
   behavior of topologicalSortMethodName
 
-  it should "soft node collection in topological order" in {
+  it should "sort node collection in topological order" in {
     val originalCollection = Seq(
       4 -> Seq(5),
       2 -> Seq(4),
@@ -46,7 +48,7 @@ abstract class AbstractGraphImplicits_SortedTopologicallySpec(
     sortedCollection should be(topologicallySorted)
   }
 
-  it should "should support disconnected graphs" in {
+  it should "support disconnected graphs" in {
     val disconnectedGraph = Seq(
       // graph A
       1 -> Seq(2, 3),
@@ -64,18 +66,21 @@ abstract class AbstractGraphImplicits_SortedTopologicallySpec(
     sortedGraph should be(topologicallySorted)
   }
 
-  it should "should not remove disconnected nodes" in {
+  it should "not remove disconnected nodes" in {
     val col2 = Seq(1 -> Nil, 2 -> Nil, 3 -> Nil)
     executeTopologicalSortMethod(col2) should contain theSameElementsAs col2
   }
 
-  it should "return the argument if its size is < 2" in {
+  it should "do nothing on empty collections" in {
     val col0 = Seq.empty
-    val col1 = Seq(1 -> Nil)
-    val col2 = Seq(1 -> Seq(2), 2 -> Nil)
     executeTopologicalSortMethod(col0) should be theSameInstanceAs col0
-    executeTopologicalSortMethod(col1) should be theSameInstanceAs col1
-    executeTopologicalSortMethod(col2) should not(be theSameInstanceAs col2)
+  }
+
+  it should "always return another instance of mutable collections" in {
+    val arr0 = Array.empty[TestNode]
+    val buf1 = ListBuffer(1 -> Nil)
+    executeTopologicalSortMethod(arr0) should (have length 0 and not(be theSameInstanceAs arr0))
+    executeTopologicalSortMethod(buf1) should (contain theSameElementsAs buf1 and not(be theSameInstanceAs buf1))
   }
 
   it should "fail due to a cycle in the graph" in {

--- a/src/test/scala/za/co/absa/commons/graph/AbstractGraphImplicits_SortedTopologicallySpec.scala
+++ b/src/test/scala/za/co/absa/commons/graph/AbstractGraphImplicits_SortedTopologicallySpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.graph
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers._
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.graph.AbstractGraphImplicits_SortedTopologicallySpec._
+
+abstract class AbstractGraphImplicits_SortedTopologicallySpec(
+  topologicalSortMethodName: String,
+  executeTopologicalSortMethod: Seq[TestNode] => Seq[TestNode]
+) extends AnyFlatSpec
+  with Matchers {
+
+  behavior of "DAGNodeTraversableOps"
+
+  behavior of topologicalSortMethodName
+
+  it should "soft node collection in topological order" in {
+    val originalCollection = Seq(
+      4 -> Seq(5),
+      2 -> Seq(4),
+      3 -> Nil,
+      1 -> Seq(2, 3, 5),
+      5 -> Nil
+    )
+
+    val sortedCollection = executeTopologicalSortMethod(originalCollection)
+
+    sortedCollection should contain theSameElementsAs originalCollection
+    sortedCollection should be(topologicallySorted)
+  }
+
+  it should "should support disconnected graphs" in {
+    val disconnectedGraph = Seq(
+      // graph A
+      1 -> Seq(2, 3),
+      3 -> Nil,
+      2 -> Seq(3),
+      // graph B
+      10 -> Seq(20, 30),
+      30 -> Nil,
+      20 -> Seq(30)
+    )
+
+    val sortedGraph = executeTopologicalSortMethod(disconnectedGraph)
+
+    sortedGraph should contain theSameElementsAs disconnectedGraph
+    sortedGraph should be(topologicallySorted)
+  }
+
+  it should "should not remove disconnected nodes" in {
+    val col2 = Seq(1 -> Nil, 2 -> Nil, 3 -> Nil)
+    executeTopologicalSortMethod(col2) should contain theSameElementsAs col2
+  }
+
+  it should "return the argument if its size is < 2" in {
+    val col0 = Seq.empty
+    val col1 = Seq(1 -> Nil)
+    val col2 = Seq(1 -> Seq(2), 2 -> Nil)
+    executeTopologicalSortMethod(col0) should be theSameInstanceAs col0
+    executeTopologicalSortMethod(col1) should be theSameInstanceAs col1
+    executeTopologicalSortMethod(col2) should not(be theSameInstanceAs col2)
+  }
+
+  it should "fail due to a cycle in the graph" in {
+    val cyclicGraph = Seq(
+      1 -> Seq(2),
+      2 -> Seq(3),
+      3 -> Seq(1)
+    )
+    intercept[IllegalArgumentException] {
+      executeTopologicalSortMethod(cyclicGraph)
+    }
+  }
+}
+
+object AbstractGraphImplicits_SortedTopologicallySpec {
+
+  type TestNodeId = Int
+  type TestRefNodeIds = Seq[TestNodeId]
+  type TestNode = (TestNodeId, TestRefNodeIds)
+
+  private def topologicallySorted: BeMatcher[Seq[TestNode]] = TopologicallySortedMatcher
+
+  private object TopologicallySortedMatcher extends BeMatcher[Seq[TestNode]] {
+    override def apply(xs: Seq[TestNode]): MatchResult = {
+      val seen = xs.foldLeft(Option(Set.empty[Int])) {
+        case (Some(seen), (id, ids)) if ids forall (!seen(_)) => Some(seen + id)
+        case _ => None // mismatch found, skip the rest of nodes
+      }
+      MatchResult(
+        seen.isDefined,
+        s"${asString(xs)} was not sorted in topological order",
+        s"${asString(xs)} was sorted in topological order"
+      )
+    }
+
+    private def asString(xs: Seq[TestNode]): String =
+      xs.map { case (id, ids) =>
+        val sb = new StringBuilder
+        sb ++= id.toString
+        if (ids.nonEmpty) sb ++= s" -> ${ids mkString ","}"
+        s"($sb)"
+      }.toString
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallyBySpec.scala
+++ b/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallyBySpec.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.graph
+
+import za.co.absa.commons.graph.GraphImplicits._
+
+class GraphImplicits_SortedTopologicallyBySpec
+  extends AbstractGraphImplicits_SortedTopologicallySpec(
+    "sortedTopologicallyBy",
+    _.sortedTopologicallyBy(_._1, _._2)
+  )

--- a/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallySpec.scala
+++ b/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallySpec.scala
@@ -25,7 +25,7 @@ class GraphImplicits_SortedTopologicallySpec
   extends AbstractGraphImplicits_SortedTopologicallySpec(
     "sortedTopologically",
     (xs: Seq[(TestNodeId, TestRefNodeIds)]) => {
-      implicit val nodeIdMapping: DAGNodeIdMapping[TestNode, TestNodeId] = TestNodeIdMapping
+      implicit val nim: DAGNodeIdMapping[TestNode, TestNodeId] = TestNodeIdMapping
       xs.sortedTopologically()
     }
   )
@@ -34,9 +34,9 @@ object GraphImplicits_SortedTopologicallySpec {
 
   implicit object TestNodeIdMapping extends DAGNodeIdMapping[TestNode, TestNodeId] {
 
-    override def currentId(n: TestNode): TestNodeId = n._1
+    override def selfId(n: TestNode): TestNodeId = n._1
 
-    override def outboundIds(n: TestNode): Seq[TestNodeId] = n._2
+    override def refIds(n: TestNode): Seq[TestNodeId] = n._2
   }
 
 }

--- a/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallySpec.scala
+++ b/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallySpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.graph
+
+import za.co.absa.commons.graph.AbstractGraphImplicits_SortedTopologicallySpec.{TestNode, TestNodeId, TestRefNodeIds}
+import za.co.absa.commons.graph.GraphImplicits._
+import za.co.absa.commons.graph.GraphImplicits_SortedTopologicallySpec._
+
+
+class GraphImplicits_SortedTopologicallySpec
+  extends AbstractGraphImplicits_SortedTopologicallySpec(
+    "sortedTopologically",
+    (xs: Seq[(TestNodeId, TestRefNodeIds)]) => {
+      implicit val nodeIdMapping: DAGNodeIdMapping[TestNode, TestNodeId] = TestNodeIdMapping
+      xs.sortedTopologically()
+    }
+  )
+
+object GraphImplicits_SortedTopologicallySpec {
+
+  implicit object TestNodeIdMapping extends DAGNodeIdMapping[TestNode, TestNodeId] {
+
+    override def currentId(n: TestNode): TestNodeId = n._1
+
+    override def outboundIds(n: TestNode): Seq[TestNodeId] = n._2
+  }
+
+}


### PR DESCRIPTION
# Graph Utils

### Topological sorting
```scala
import za.co.absa.commons.graph.GraphImplicits._

val myNodes: Seq[MyNode] = ??? // an arbitrary sequence of objects that can represent graph nodes 

val sortedNodes = myNodes.sortedTopologicallyBy(_.id, _.refIds) // arguments are functions that return a self ID and outbound IDs for every node in the collection 

// ... or using implicit `DAGNodeIDMapping` instance instead of explicitly passing mapping functions as arguments

implicit object MyNodeIdMapping extends DAGNodeIdMapping[MyNode, NodeId] {
   override def currentId(n: MyNode): NodeId = ???
   override def outboundIds(n: MyNode): Seq[NodeId] = ???
}

val sortedNodes = myNodes.sortedTopologically()
```
