### PR TITLE
Configuration Utils: missing property error message to report full pr…

### DIFF
--- a/src/main/scala/org/apache/commons/configuration/SubsetConfigurationMethods.scala
+++ b/src/main/scala/org/apache/commons/configuration/SubsetConfigurationMethods.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.configuration
+
+object SubsetConfigurationMethods {
+
+  implicit class SubsetConfigurationOps(val conf: SubsetConfiguration) extends AnyVal {
+
+    // The `SubsetConfiguration.getParentKey()` method is protected,
+    // so we apply this implicit proxy to make the method publicly
+    // accessible without resorting to the reflection.
+    def getParentKey: String => String = conf.getParentKey
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/config/ConfigurationImplicitsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/config/ConfigurationImplicitsSpec.scala
@@ -99,6 +99,11 @@ class ConfigurationImplicitsSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "report the full missing property name in case of SubsetConfiguration" in {
+    val fooBarConf = new BaseConfiguration() subset "foo" subset "bar"
+    intercept[NoSuchElementException](fooBarConf getRequiredString "baz").getMessage should include("foo.bar.baz")
+  }
+
   it should "propagate exceptions other than missing property" in {
     object TestException extends Exception
 


### PR DESCRIPTION
…operty name in case of "SubsetConfiguration"

```scala
val conf: Configuration = ???
conf.subset("foo").getString("bar") // when missing, should mention the "foo.bar" property in the error message, not just "bar"
```
