### PR TITLE
commons #77 Fix various Scala reflection assertion errors

### DIFF
--- a/src/main/scala/za/co/absa/commons/reflect/ReflectionUtils.scala
+++ b/src/main/scala/za/co/absa/commons/reflect/ReflectionUtils.scala
@@ -121,7 +121,7 @@ object ReflectionUtils {
 
     def reflectClass(c: Class[_]) = {
       val members =
-        try mirror.classSymbol(c).toType.members
+        try mirror.classSymbol(c).toType.decls
         catch {
           // a workaround for Scala bug #12190
           case _: Symbols#CyclicReference => Nil


### PR DESCRIPTION
Fixes: #77 

Replace `TypeApi.members` with `TypeApi.decls` to avoid unnecessary scanning inherited members