### PR TITLE
commons #87 Support for Scala 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ Selection of useful reusable components
 
 ---
 
+# Building
+
+### Switch the codebase to the required Scala version.
+By default, Scala 2.11 is used. To build _Commons_ for another Scala version, switch to the required Scala version first. 
+```shell
+# E.g. to switch to Scala 2.13 use
+mvn scala-cross-build:change-version -Pscala-2.13
+```
+
+### Build the project
+When building the project activate a Scala profile corresponding to the Scala version of the codebase.
+```shell
+# E.g. for Scala 2.13 use
+mvn clean install -Pscala-2.13
+```
+
+### Building for all supported Scala versions
+```shell
+./build-all.sh
+```
+
 # Collection utils
 
 ```scala
@@ -552,7 +573,17 @@ spark.listenerManager.register(myListener)
 
 ### Spark Schema Utils
 
-Provides methods for working with schemas, its comparison and alignment.  
+>
+>**Note:**
+>Different _Scala_ variants of the _Schema Utils_ are compiled against different _Spark_, _Json4s_ and _Jackson_ versions:
+>
+>| | Scala 2.11 | Scala 2.12 | Scala 2.13 | 
+>|---|---|---|---|
+>|Spark| 2.4 | 3.1 | 3.2 |
+>|Json4s| 3.5 | 3.7 | 3.7 |
+>|Jackson| 2.6 | 2.10 | 2.12 |
+
+_Spark Schema Utils_ provides methods for working with schemas, its comparison and alignment.  
 
 1. Schema comparison returning true/false. Ignores the order of columns
          

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2020 ABSA Group Limited
 #
@@ -18,21 +18,43 @@
 # THIS SCRIPT IS INTENDED FOR LOCAL DEV USAGE ONLY
 #
 
-BASE_DIR=$(dirname "$0")
+SCALA_VERSIONS=(2.11 2.12 2.13)
 
-cross_build() {
-  SCALA_VER=$1
-  echo "Building with Scala $SCALA_VER"
-  find $BASE_DIR/target/* -type d -exec rm -rf {} \;
-  mvn scala-cross-build:change-version -Pscala-$SCALA_VER
-  mvn install
+BASE_DIR=$(dirname "$0")
+MODULE_DIRS=$(find "$BASE_DIR" -type f -name "pom.xml" -printf '%h\n')
+MVN_EXEC="mvn"
+
+print_title() {
+  echo "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"
+  echo "                           $1                                                  "
+  echo "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░"
 }
 
-# ------------------------------------------------
+cross_build() {
+  bin_ver=$1
 
-mvn clean
+  # pre-cleaning
+  for dir in $MODULE_DIRS; do
+    rm -rf "$dir"/target
+  done
 
-cross_build 2.11
-cross_build 2.12
+  print_title "Switching to Scala $bin_ver"
+  $MVN_EXEC scala-cross-build:change-version -Pscala-"$bin_ver"
 
-mvn scala-cross-build:restore-version
+  print_title "Building with Scala $bin_ver"
+  $MVN_EXEC install -Pscala-"$bin_ver" -DskipTests -T 1C || exit 1
+}
+
+# -------------------------------------------------------------------------------
+
+for v in "${SCALA_VERSIONS[@]}"; do
+  cross_build "$v"
+done
+
+print_title "Restoring POM-files"
+$MVN_EXEC scala-cross-build:change-version -Pscala-"${SCALA_VERSIONS[0]}"
+
+# remove backup files
+for dir in $MODULE_DIRS; do
+  rm -f "$dir"/pom.xml.bkp
+done

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -46,7 +47,7 @@
 
     <groupId>za.co.absa.commons</groupId>
     <artifactId>commons_2.11</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 
     <properties>
         <scm.url>http://github.com/AbsaOSS/commons/tree/master</scm.url>
@@ -56,14 +57,44 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <json4s.version>3.5.5</json4s.version>
-
         <default.scala.binary.version>2.11</default.scala.binary.version>
         <default.scala.version>${scala_2.11.version}</default.scala.version>
+        <default.class-graph.version>${class-graph-112.version}</default.class-graph.version>
+        <default.spark.version>${spark-24.version}</default.spark.version>
+        <default.json4s.version>${json4s-35.version}</default.json4s.version>
+        <default.jackson.version>${jackson-26.version}</default.jackson.version>
+
+        <!-- Json4s versions -->
+
+        <json4s-35.version>3.5.5</json4s-35.version>
+        <json4s-37.version>3.7.0-M11</json4s-37.version>
+        <json4s.version>${default.json4s.version}</json4s.version>
+
+        <!-- Jackson version -->
+
+        <jackson-26.version>2.6.7.4</jackson-26.version>
+        <jackson-210.version>2.10.0</jackson-210.version>
+        <jackson-212.version>2.12.0</jackson-212.version>
+        <jackson.version>${default.jackson.version}</jackson.version>
+
+        <!-- Class-Graph versions -->
+
+        <class-graph-112.version>1.12.5</class-graph-112.version>
+        <class-graph-113.version>1.13.3</class-graph-113.version>
+        <class-graph.version>${default.class-graph.version}</class-graph.version>
+
+        <!-- Spark versions -->
+
+        <spark-24.version>2.4.4</spark-24.version>
+        <spark-31.version>3.1.2</spark-31.version>
+        <spark-32.version>3.2.0</spark-32.version>
+        <spark.version>${default.spark.version}</spark.version>
+
+        <!-- Scala versions -->
 
         <scala_2.11.version>2.11.12</scala_2.11.version>
-        <scala_2.12.version>2.12.10</scala_2.12.version>
-        <scala_2.13.version>2.13.1</scala_2.13.version>
+        <scala_2.12.version>2.12.15</scala_2.12.version>
+        <scala_2.13.version>2.13.7</scala_2.13.version>
 
         <!-- Controlled by `scala-cross-build` plugin -->
         <scala.version>2.11.12</scala.version>
@@ -144,31 +175,31 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>2.4.4</version>
+            <version>${spark.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>2.4.4</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>za.co.absa</groupId>
-            <artifactId>spark-hofs_${scala.binary.version}</artifactId>
-            <version>0.4.0</version>
+            <version>${spark.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.7.4</version>
+            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.scala-graph</groupId>
             <artifactId>graph-core_${scala.binary.version}</artifactId>
-            <version>1.12.5</version>
+            <version>${class-graph.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.31</version>
             <optional>true</optional>
         </dependency>
 
@@ -355,20 +386,42 @@
             <properties>
                 <scala.binary.version>2.11</scala.binary.version>
                 <scala.version>${scala_2.11.version}</scala.version>
+                <class-graph.version>${class-graph-112.version}</class-graph.version>
+                <spark.version>${spark-24.version}</spark.version>
+                <json4s.version>${json4s-35.version}</json4s.version>
+                <jackson.version>${jackson-26.version}</jackson.version>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>za.co.absa</groupId>
+                    <artifactId>spark-hofs_${scala.binary.version}</artifactId>
+                    <version>0.4.0</version>
+                    <optional>true</optional>
+                </dependency>
+            </dependencies>
         </profile>
+
         <profile>
             <id>scala-2.12</id>
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>${scala_2.12.version}</scala.version>
+                <class-graph.version>${class-graph-112.version}</class-graph.version>
+                <spark.version>${spark-31.version}</spark.version>
+                <json4s.version>${json4s-37.version}</json4s.version>
+                <jackson.version>${jackson-210.version}</jackson.version>
             </properties>
         </profile>
+
         <profile>
             <id>scala-2.13</id>
             <properties>
                 <scala.binary.version>2.13</scala.binary.version>
                 <scala.version>${scala_2.13.version}</scala.version>
+                <class-graph.version>${class-graph-113.version}</class-graph.version>
+                <spark.version>${spark-32.version}</spark.version>
+                <json4s.version>${json4s-37.version}</json4s.version>
+                <jackson.version>${jackson-212.version}</jackson.version>
             </properties>
         </profile>
 

--- a/src/main/scala/za/co/absa/commons/scalatest/WhitespaceNormalizations.scala
+++ b/src/main/scala/za/co/absa/commons/scalatest/WhitespaceNormalizations.scala
@@ -19,8 +19,6 @@ package za.co.absa.commons.scalatest
 import org.scalactic.{AbstractStringUniformity, Uniformity}
 import za.co.absa.commons.scalatest.WhitespaceNormalizations.WhiteSpaceRegex
 
-import scala.collection.immutable.StringLike
-
 object WhitespaceNormalizations extends WhitespaceNormalizations {
   val WhiteSpaceRegex = "[\\s\\h]+"
 }
@@ -40,8 +38,10 @@ trait WhitespaceNormalizations {
 
   val lineWhiteSpaceRemoved: Uniformity[String] = new AbstractStringUniformity {
     override def normalized(s: String): String = {
-      (s: StringLike[String])
-        .lines
+      // method `linesIterator` is un-deprecated in Scala 2.13 due to collision with the JDK 11's `lines` method.
+      // noinspection ScalaDeprecation
+      s
+        .linesIterator
         .map(_.replaceAll(WhiteSpaceRegex, ""))
         .filter(_.nonEmpty)
         .toArray

--- a/src/main/scala/za/co/absa/commons/spark/HofsAdapter.scala
+++ b/src/main/scala/za/co/absa/commons/spark/HofsAdapter.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.spark
+
+import org.apache.spark.SPARK_VERSION
+import org.apache.spark.sql.Column
+import za.co.absa.commons.reflect.ReflectionUtils
+import za.co.absa.commons.version.Version
+import za.co.absa.commons.version.Version.VersionStringInterpolator
+
+import scala.reflect.runtime.universe._
+
+trait HofsAdapter {
+
+  /**
+    * For Spark versions prior 3.0.0, delegates to {{{hofs.transform()}}}
+    * Otherwise delegates to the native Spark method.
+    */
+  val transform: (Column, Column => Column) => Column = {
+    val fnRefAST =
+      if (Version.asSemVer(SPARK_VERSION) < semver"3.0.0")
+        q"za.co.absa.spark.hofs.transform(_: Column, _: Column => Column)"
+      else
+        q"org.apache.spark.sql.functions.transform(_: Column, _: Column => Column)"
+    ReflectionUtils.compile(
+      q"""
+          import org.apache.spark.sql.Column
+          $fnRefAST
+          """
+    )(Map.empty)
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/spark/SchemaUtils.scala
+++ b/src/main/scala/za/co/absa/commons/spark/SchemaUtils.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{ArrayType, DataType, StructField, StructType}
 import org.apache.spark.sql.{Column, DataFrame}
 
-object SchemaUtils {
+object SchemaUtils extends HofsAdapter {
   /**
    * Compares 2 array fields of a dataframe schema.
    *
@@ -117,7 +117,6 @@ object SchemaUtils {
    * @return Sorted DF to conform to schema
    */
   def getDataFrameSelector(schema: StructType): List[Column] = {
-    import za.co.absa.spark.hofs._
 
     def processArray(arrType: ArrayType, column: Column, name: String): Column = {
       arrType.elementType match {

--- a/src/test/scala/za/co/absa/commons/graph/AbstractGraphImplicits_SortedTopologicallySpec.scala
+++ b/src/test/scala/za/co/absa/commons/graph/AbstractGraphImplicits_SortedTopologicallySpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.matchers._
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.commons.graph.AbstractGraphImplicits_SortedTopologicallySpec._
 
-import scala.collection.mutable.ListBuffer
+import scala.collection.{Seq, mutable}
 
 abstract class AbstractGraphImplicits_SortedTopologicallySpec(
   topologicalSortMethodName: String,
@@ -82,7 +82,7 @@ abstract class AbstractGraphImplicits_SortedTopologicallySpec(
 
   it should "always return another instance of mutable collections" in {
     val arr0 = Array.empty[TestNode]
-    val buf1 = ListBuffer(1 -> Nil)
+    val buf1 = mutable.ListBuffer(1 -> Nil)
     executeTopologicalSortMethod(arr0) should (have length 0 and not(be theSameInstanceAs arr0))
     executeTopologicalSortMethod(buf1) should (contain theSameElementsAs buf1 and not(be theSameInstanceAs buf1))
   }

--- a/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallyBySpec.scala
+++ b/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallyBySpec.scala
@@ -21,5 +21,7 @@ import za.co.absa.commons.graph.GraphImplicits._
 class GraphImplicits_SortedTopologicallyBySpec
   extends AbstractGraphImplicits_SortedTopologicallySpec(
     "sortedTopologicallyBy",
-    _.sortedTopologicallyBy(_._1, _._2)
+    // `toSeq` is required for Scala 2.13
+    // noinspection RedundantCollectionConversion
+    _.toSeq.sortedTopologicallyBy(_._1, _._2)
   )

--- a/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallySpec.scala
+++ b/src/test/scala/za/co/absa/commons/graph/GraphImplicits_SortedTopologicallySpec.scala
@@ -24,9 +24,11 @@ import za.co.absa.commons.graph.GraphImplicits_SortedTopologicallySpec._
 class GraphImplicits_SortedTopologicallySpec
   extends AbstractGraphImplicits_SortedTopologicallySpec(
     "sortedTopologically",
-    (xs: Seq[(TestNodeId, TestRefNodeIds)]) => {
+    (xs: collection.Seq[(TestNodeId, TestRefNodeIds)]) => {
       implicit val nim: DAGNodeIdMapping[TestNode, TestNodeId] = TestNodeIdMapping
-      xs.sortedTopologically()
+      // `toSeq` is required for Scala 2.13
+      // noinspection RedundantCollectionConversion
+      xs.toSeq.sortedTopologically()
     }
   )
 
@@ -36,7 +38,11 @@ object GraphImplicits_SortedTopologicallySpec {
 
     override def selfId(n: TestNode): TestNodeId = n._1
 
-    override def refIds(n: TestNode): Seq[TestNodeId] = n._2
+    override def refIds(n: TestNode): Seq[TestNodeId] = {
+      // `toSeq` is required for Scala 2.13
+      // noinspection RedundantCollectionConversion
+      n._2.toSeq
+    }
   }
 
 }

--- a/src/test/scala/za/co/absa/commons/scalatest/EnvFixtureSpec.scala
+++ b/src/test/scala/za/co/absa/commons/scalatest/EnvFixtureSpec.scala
@@ -16,10 +16,9 @@
 
 package za.co.absa.commons.scalatest
 
-import org.apache.avro.reflect.MapEntry
-import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfter, Entry}
 
 import scala.collection.JavaConverters._
 
@@ -48,7 +47,7 @@ class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with Befo
       System.getenv.get(k) should equal(System.getenv(k))
       System.getenv.keySet should contain(k)
       System.getenv.values should contain(System.getenv(k))
-      System.getenv.entrySet should contain(new MapEntry(k, System.getenv(k)))
+      System.getenv.entrySet should contain(Entry(k, System.getenv(k)))
       System.getenv.values should have size System.getenv.keySet.size.toLong
       System.getenv.entrySet should have size System.getenv.keySet.size.toLong
     }
@@ -68,7 +67,7 @@ class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with Befo
     System.getenv("PATH") should equal(System.getenv.get("PATH"))
     System.getenv.keySet should contain("PATH")
     System.getenv.values should contain(System.getenv("PATH"))
-    System.getenv.entrySet should contain(new MapEntry("PATH", System.getenv("PATH")))
+    System.getenv.entrySet should contain(Entry("PATH", System.getenv("PATH")))
     System.getenv.values should have size System.getenv.keySet.size.toLong
     System.getenv.entrySet should have size System.getenv.keySet.size.toLong
   }


### PR DESCRIPTION
fixes #87

- Fixed source code differences between Scala versions 2.11(12) and 2.13
- The POM version is bumped up to 0.2 due to possible breaking changes in _Spark Schema Utils_
- _Spark_, _Json4s_ and _Jackson_ versions are selected according to the Scala profile in use. Thus `commons_2.11` is compiled against _Spark 2.4_, `commons_2.12` - _Spark 3.1_ and `commons_2.13` - _Spark 3.2_
- remove _HOFS_ dependency for Spark 3.0+