### PR TITLE
#44 "Path" used on Windows vs "PATH" on other OS

### DIFF
--- a/src/main/scala/za/co/absa/commons/os/OperatingSystem.scala
+++ b/src/main/scala/za/co/absa/commons/os/OperatingSystem.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.os
+
+
+object OperatingSystem {
+
+  // adapted from https://stackoverflow.com/a/31547504/1773349
+
+  object OperatingSystems extends Enumeration {
+    val WINDOWS, LINUX, MAC, SOLARIS, OTHER = Value
+  }
+
+  def getOsByOsName(osName: String): OperatingSystems.Value = {
+    import OperatingSystem.OperatingSystems._
+
+    osName.toLowerCase match {
+      case os if os.contains("win") => WINDOWS
+      case os if os.contains("nix") || os.contains("nux") || os.contains("aix") => LINUX
+      case os if os.contains("mac") => MAC
+      case os if os.contains("sunos") => SOLARIS
+      case _ => OTHER
+    }
+  }
+
+  def getCurrentOs: OperatingSystems.Value = {
+    getOsByOsName(System.getProperty("os.name"))
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/os/OperatingSystemSpec.scala
+++ b/src/test/scala/za/co/absa/commons/os/OperatingSystemSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.os
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.os.OperatingSystem.OperatingSystems
+
+
+class OperatingSystemSuite extends AnyFlatSpec with Matchers {
+
+  "OperatingSystem util" should "correctly find out OS" in {
+    OperatingSystem.getOsByOsName("Windows 10") shouldBe OperatingSystems.WINDOWS
+    OperatingSystem.getOsByOsName("Linux") shouldBe OperatingSystems.LINUX
+    OperatingSystem.getOsByOsName("Mac OS X") shouldBe OperatingSystems.MAC
+    OperatingSystem.getOsByOsName("SunOs") shouldBe OperatingSystems.SOLARIS
+
+    OperatingSystem.getOsByOsName("my own special os") shouldBe OperatingSystems.OTHER
+  }
+}

--- a/src/test/scala/za/co/absa/commons/scalatest/EnvFixtureSpec.scala
+++ b/src/test/scala/za/co/absa/commons/scalatest/EnvFixtureSpec.scala
@@ -19,6 +19,8 @@ package za.co.absa.commons.scalatest
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfter, Entry}
+import za.co.absa.commons.os.OperatingSystem
+import za.co.absa.commons.os.OperatingSystem.OperatingSystems
 
 import scala.collection.JavaConverters._
 
@@ -31,19 +33,25 @@ class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with Befo
     System.getenv.keySet()
   }
 
+  private val pathName = OperatingSystem.getCurrentOs match {
+    case OperatingSystems.WINDOWS => "Path" // this is what the variable actually by default looks like, at least on Win10
+    case _ => "PATH"
+  }
+
   it should "set environment variable" in {
     System.getenv("FOO") should be(null) // check the testing env doesn't exist
-    System.getenv("PATH") should not be empty // check the reference env exists
+    System.getenv(pathName) should not be empty // check the reference env exists
 
     setEnv("FOO", "42") // set testing env
 
     // check testing env is visible through the standard Java API
     System.getenv("FOO") should equal("42")
     // ... as well as the reference env
-    System.getenv("PATH") should not be empty
+    System.getenv(pathName) should not be empty
 
     // System.getenv(String) should be consistent with System.getenv.xxx()
-    Seq("FOO", "PATH").map { k =>
+    Seq("FOO", pathName).map { k =>
+      // on Windows, `System.getenv("pAth")` works fine, whereas `System.getenv.get(path)` requires correct case.
       System.getenv.get(k) should equal(System.getenv(k))
       System.getenv.keySet should contain(k)
       System.getenv.values should contain(System.getenv(k))
@@ -55,7 +63,7 @@ class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with Befo
 
   it should "clean testing environment variables after the test" in {
     System.getenv("FOO") should be(null) // check the testing env no longer exists
-    System.getenv("PATH") should not be empty // check the reference env still exists
+    System.getenv(pathName) should not be empty // check the reference env still exists
 
     // check consistency
     System.getenv.get("FOO") should be(null)
@@ -64,10 +72,10 @@ class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with Befo
     System.getenv.values should have size System.getenv.keySet.size.toLong
     System.getenv.entrySet should have size System.getenv.keySet.size.toLong
 
-    System.getenv("PATH") should equal(System.getenv.get("PATH"))
-    System.getenv.keySet should contain("PATH")
-    System.getenv.values should contain(System.getenv("PATH"))
-    System.getenv.entrySet should contain(Entry("PATH", System.getenv("PATH")))
+    System.getenv(pathName) should equal(System.getenv.get(pathName))
+    System.getenv.keySet should contain(pathName)
+    System.getenv.values should contain(System.getenv(pathName))
+    System.getenv.entrySet should contain(Entry(pathName, System.getenv(pathName)))
     System.getenv.values should have size System.getenv.keySet.size.toLong
     System.getenv.entrySet should have size System.getenv.keySet.size.toLong
   }


### PR DESCRIPTION
This PR attempts to use the `Path` environment variable instead of `PATH` on Windows.

The underlying reason for this change is that even though
```scala
System.getenv("pAth") // any case variant will work to pick up content of PATH or Path
```
works fine, the following does not:
```scala
Seq("PATH").map { k =>
      System.getenv.get(k) should equal(System.getenv(k))
}
```

On Windows, `System.getenv("pAth")` returns the correct content of `Path` (the actual variable name on Win 10), whereas `System.getenv.get(path)` requires the correct case.

An alternative solution could exist, but it would require a different setEnv routine. It might look like this (shown in Java):
```java
public static void setEnvReplacing(Map<String, String> envs) {
    try {
        // the map must be defined this way to work: https://stackoverflow.com/a/22558584/1773349
        Map<String, String> compatibleMap = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
        compatibleMap.putAll(envs);

        Class<?> pec = Class.forName("java.lang.ProcessEnvironment");
        Field tef = pec.getDeclaredField("theEnvironment");
        tef.setAccessible(true);

        Map<String, String> env = (Map<String, String>) tef.get(null);
        env.clear();
        env.putAll(compatibleMap);

        Field tcief = pec.getDeclaredField("theCaseInsensitiveEnvironment");
        tcief.setAccessible(true);
        Map<String, String> cienv = (Map<String, String>) tcief.get(null);
        cienv.clear();
        cienv.putAll(compatibleMap);
    } catch (Exception e) {
        System.err.println(e);
    }
}
```
However, in such a case, all existing env variables would need to be `clear`ed and reapplied.

 