### PR TITLE
Bugfix/commons 101 illegal cyclic reference

### DIFF
--- a/src/main/scala/za/co/absa/commons/reflect/FieldValueExtractor.scala
+++ b/src/main/scala/za/co/absa/commons/reflect/FieldValueExtractor.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.reflect
+
+import za.co.absa.commons.annotation.DeveloperApi
+import za.co.absa.commons.reflect.ReflectionUtils.allInterfacesOf
+
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.{Mirror, runtimeMirror}
+
+@DeveloperApi
+class FieldValueExtractor[A: ClassTag, B](o: AnyRef, fieldName: String) {
+
+  private val mirror: Mirror = runtimeMirror(getClass.getClassLoader)
+
+  def extract(): B = {
+    val declaringClass = implicitly[ClassTag[A]].runtimeClass
+    reflectClassHierarchy(declaringClass)
+      .orElse {
+        // The field might be declared in a trait.
+        reflectInterfaces(declaringClass)
+      }
+      .getOrElse(
+        throw new NoSuchFieldException(s"${declaringClass.getName}.$fieldName")
+      )
+      .asInstanceOf[B]
+  }
+
+  @tailrec
+  private def reflectClassHierarchy(c: Class[_]): Option[_] =
+    if (c == classOf[AnyRef]) None
+    else {
+      val maybeValue: Option[Any] = reflectClass(c)
+      if (maybeValue.isDefined) maybeValue
+      else {
+        val superClass = c.getSuperclass
+        if (superClass == null) None
+        else reflectClassHierarchy(superClass)
+      }
+    }
+
+  private def reflectClass(c: Class[_]): Option[Any] =
+    scalaReflectClass(c).orElse(javaReflectClass(c))
+
+  /**
+   *  may return None because:
+   *  - `Symbols#CyclicReference` (Scala bug #12190)
+   *  - `RuntimeException("scala signature")` (#80, #82)
+   */
+  private def scalaReflectClass(c: Class[_]): Option[Any] = util.Try {
+    val members = mirror.classSymbol(c).toType.decls
+    val m = members
+      .filter(smb => (
+        smb.toString.endsWith(s" $fieldName")
+          && smb.isTerm
+          && !smb.isConstructor
+          && (!smb.isMethod || smb.asMethod.paramLists.forall(_.isEmpty))
+        ))
+      .minBy(!_.isMethod)
+
+    val im = mirror.reflect(o)
+    if (m.isMethod) im.reflectMethod(m.asMethod).apply()
+    else im.reflectField(m.asTerm).get
+  }.toOption
+
+  private def javaReflectClass(c: Class[_]): Option[Any] =
+    c.getDeclaredFields.collectFirst {
+      case f if f.getName == fieldName =>
+        f.setAccessible(true)
+        f.get(o)
+    }
+
+
+  private def reflectInterfaces(c: Class[_]) = {
+    val altNames = allInterfacesOf(c)
+      .map(_.getName.replace('.', '$') + "$$" + fieldName)
+
+    c.getDeclaredFields.collectFirst {
+      case f if altNames contains f.getName =>
+        f.setAccessible(true)
+        f.get(o)
+    }
+  }
+
+}

--- a/src/test/java/za/co/absa/commons/reflect/CyclicAnnotationExample.java
+++ b/src/test/java/za/co/absa/commons/reflect/CyclicAnnotationExample.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package za.co.absa.commons.reflection;
+package za.co.absa.commons.reflect;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/test/scala/za/co/absa/commons/reflect/ClassWithCyclicAnnotation.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ClassWithCyclicAnnotation.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.reflect
+
+import za.co.absa.commons.reflection.CyclicAnnotationExample
+
+@CyclicAnnotationExample.CyclicAnnotation
+class ClassWithCyclicAnnotation {
+
+}

--- a/src/test/scala/za/co/absa/commons/reflect/ClassWithCyclicAnnotation.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ClassWithCyclicAnnotation.scala
@@ -16,9 +16,7 @@
 
 package za.co.absa.commons.reflect
 
-import za.co.absa.commons.reflection.CyclicAnnotationExample
+import za.co.absa.commons.reflect.CyclicAnnotationExample
 
 @CyclicAnnotationExample.CyclicAnnotation
-class ClassWithCyclicAnnotation {
-
-}
+class ClassWithCyclicAnnotation

--- a/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import za.co.absa.commons.reflect.ReflectionUtils.ModuleClassSymbolExtractor
 import za.co.absa.commons.reflect.ReflectionUtilsSpec._
-import za.co.absa.commons.reflection.CyclicAnnotationExample
+import za.co.absa.commons.reflect.CyclicAnnotationExample
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -136,12 +136,10 @@ class ReflectionUtilsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     ReflectionUtils.extractFieldValue[Boolean](Foo, "x") should be(Foo.x)
   }
 
-  // this class must be outside the test to trigger the exception
-  case class WrappingClass(x: ClassWithCyclicAnnotation)
-
   it should "fallback to Java reflection when Scala one fails via return type" in {
-    val obj = WrappingClass(new ClassWithCyclicAnnotation)
-    ReflectionUtils.extractFieldValue[ClassWithCyclicAnnotation](obj, "x") should not be null
+    val innerObj = new ClassWithCyclicAnnotation
+    val obj = WrappingClass(innerObj)
+    ReflectionUtils.extractFieldValue[ClassWithCyclicAnnotation](obj, "x") should be(innerObj)
   }
 
   behavior of "ModuleClassSymbolExtractor"
@@ -247,4 +245,5 @@ object ReflectionUtilsSpec {
     lazy val z = 42
   }
 
+  case class WrappingClass(x: ClassWithCyclicAnnotation)
 }

--- a/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
@@ -136,6 +136,14 @@ class ReflectionUtilsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     ReflectionUtils.extractFieldValue[Boolean](Foo, "x") should be(Foo.x)
   }
 
+  // this class must be outside the test to trigger the exception
+  case class WrappingClass(x: ClassWithCyclicAnnotation)
+
+  it should "fallback to Java reflection when Scala one fails via return type" in {
+    val obj = WrappingClass(new ClassWithCyclicAnnotation)
+    ReflectionUtils.extractFieldValue[ClassWithCyclicAnnotation](obj, "x") should not be null
+  }
+
   behavior of "ModuleClassSymbolExtractor"
 
   it should "extract objects" in {


### PR DESCRIPTION
fixes #101

`Ilegal cyclic reference` can be caused by multiple methods from scala reflection API, this PR moves the whole scala reflection code block into Try block to work around the issue.

