### PR TITLE
commons #105 Failing tests on Windows - EnvFixtureSpec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,9 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>WDF TestSuite.txt</filereports>
+                    <environmentVariables>
+                        <TEST_ENV_VAR_EnvFixtureSpec>some_initial_value</TEST_ENV_VAR_EnvFixtureSpec>
+                    </environmentVariables>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/test/scala/za/co/absa/commons/scalatest/EnvFixtureSpec.scala
+++ b/src/test/scala/za/co/absa/commons/scalatest/EnvFixtureSpec.scala
@@ -19,16 +19,14 @@ package za.co.absa.commons.scalatest
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfter, Entry}
-import za.co.absa.commons.lang.OperatingSystem
-import za.co.absa.commons.scalatest.EnvFixtureSpec.AprioriExistingEnvVarName
+import za.co.absa.commons.scalatest.EnvFixtureSpec.{ExistingEnvVarName, ExistingEnvVarValue}
 
 import scala.collection.JavaConverters._
 
 object EnvFixtureSpec {
-  private val AprioriExistingEnvVarName = OperatingSystem.getCurrentOs match {
-    case OperatingSystem.WINDOWS => "Path" // this is what the variable actually by default looks like, at least on Win10
-    case _ => "PATH"
-  }
+  // defined in scalatest plugin in pom.xml
+  private val ExistingEnvVarName = "TEST_ENV_VAR_EnvFixtureSpec"
+  private val ExistingEnvVarValue = "some_initial_value"
 }
 
 class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with BeforeAndAfter {
@@ -42,17 +40,17 @@ class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with Befo
 
   it should "set environment variable" in {
     System.getenv("FOO") should be(null) // check the testing env doesn't exist
-    System.getenv(AprioriExistingEnvVarName) should not be empty // check the reference env exists
+    System.getenv(ExistingEnvVarName) should equal(ExistingEnvVarValue) // check the reference env exists
 
     setEnv("FOO", "42") // set testing env
 
     // check testing env is visible through the standard Java API
     System.getenv("FOO") should equal("42")
     // ... as well as the reference env
-    System.getenv(AprioriExistingEnvVarName) should not be empty
+    System.getenv(ExistingEnvVarName) should equal(ExistingEnvVarValue)
 
     // System.getenv(String) should be consistent with System.getenv.xxx()
-    Seq("FOO", AprioriExistingEnvVarName).map { k =>
+    Seq("FOO", ExistingEnvVarName).map { k =>
       // on Windows, `System.getenv("pAth")` works fine, whereas `System.getenv.get(path)` requires correct case.
       System.getenv.get(k) should equal(System.getenv(k))
       System.getenv.keySet should contain(k)
@@ -65,7 +63,7 @@ class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with Befo
 
   it should "clean testing environment variables after the test" in {
     System.getenv("FOO") should be(null) // check the testing env no longer exists
-    System.getenv(AprioriExistingEnvVarName) should not be empty // check the reference env still exists
+    System.getenv(ExistingEnvVarName) should not be empty // check the reference env still exists
 
     // check consistency
     System.getenv.get("FOO") should be(null)
@@ -74,10 +72,10 @@ class EnvFixtureSpec extends AnyFlatSpec with Matchers with EnvFixture with Befo
     System.getenv.values should have size System.getenv.keySet.size.toLong
     System.getenv.entrySet should have size System.getenv.keySet.size.toLong
 
-    System.getenv(AprioriExistingEnvVarName) should equal(System.getenv.get(AprioriExistingEnvVarName))
-    System.getenv.keySet should contain(AprioriExistingEnvVarName)
-    System.getenv.values should contain(System.getenv(AprioriExistingEnvVarName))
-    System.getenv.entrySet should contain(Entry(AprioriExistingEnvVarName, System.getenv(AprioriExistingEnvVarName)))
+    System.getenv(ExistingEnvVarName) should equal(System.getenv.get(ExistingEnvVarName))
+    System.getenv.keySet should contain(ExistingEnvVarName)
+    System.getenv.values should contain(System.getenv(ExistingEnvVarName))
+    System.getenv.entrySet should contain(Entry(ExistingEnvVarName, System.getenv(ExistingEnvVarName)))
     System.getenv.values should have size System.getenv.keySet.size.toLong
     System.getenv.entrySet should have size System.getenv.keySet.size.toLong
   }


### PR DESCRIPTION
fixes #105 

Add a predefined environment variable to a scalatest plugin, that is set before creating a fork process, so that we don't have to rely on any pre-existing env var on the build agent.