### PR TITLE
#107 Extract Enceladus utils into commons and reorganize implicits 

### DIFF
--- a/src/main/scala/za/co/absa/commons/io/LocalFileSystemUtils.scala
+++ b/src/main/scala/za/co/absa/commons/io/LocalFileSystemUtils.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.io
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+object LocalFileSystemUtils {
+
+  /**
+   * Check if a given files exists on the local file system
+   */
+  def localExists(path: String): Boolean = {
+    new File(path).exists()
+  }
+
+  /**
+   * Reads a local file fully and returns its content.
+   *
+   * @param path A path to a file.
+   * @return The file's content.
+   */
+  def readLocalFile(path: String): String = {
+    Files.readAllLines(Paths.get(path), StandardCharsets.UTF_8).toArray.mkString("\n")
+  }
+
+  /**
+   * Replaces tilde ('~') with the home dir.
+   *
+   * @param path An input path.
+   * @return An absolute output path.
+   */
+  def replaceHome(path: String): String = {
+    if (path.matches("^~.*")) {
+      // not using replaceFirst as it interprets the backslash in Windows path as escape character mangling the result
+      System.getProperty("user.home") + path.substring(1)
+    } else {
+      path
+    }
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/CollectionImplicits.scala
+++ b/src/main/scala/za/co/absa/commons/lang/CollectionImplicits.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 
+@deprecated("Use type-specific ...Extension instead")
 object CollectionImplicits {
 
   implicit class IteratorOps[A](val iter: Iterator[A]) extends AnyVal {

--- a/src/main/scala/za/co/absa/commons/lang/OptionImplicits.scala
+++ b/src/main/scala/za/co/absa/commons/lang/OptionImplicits.scala
@@ -18,6 +18,7 @@ package za.co.absa.commons.lang
 
 import za.co.absa.commons.lang.TypeConstraints.not
 
+@deprecated("Use type-specific ...Extension instead")
 object OptionImplicits {
 
   implicit class StringWrapper(val s: String) extends AnyVal {

--- a/src/main/scala/za/co/absa/commons/lang/extensions/AnyExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/AnyExtension.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+object AnyExtension {
+
+  implicit class AnyOps[A <: Any](val a: A) extends AnyVal {
+
+    /**
+     * Applies `applyFn` to the value with `maybeArg` as second argument in case `maybeArg` is not None,
+     * otherwise does nothing and returns the same value as was called on.
+     */
+    def optionally[B](applyFn: (A, B) => A, maybeArg: Option[B]): A = maybeArg.map(applyFn(a, _)).getOrElse(a)
+
+    /**
+     * The same as [[optionally]], but with signature that is more type inference friendly.
+     */
+    def having[B](maybeArg: Option[B])(applyFn: (A, B) => A): A = optionally(applyFn, maybeArg)
+
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/extensions/ArrayExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/ArrayExtension.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import scala.reflect.ClassTag
+
+object ArrayExtension {
+
+  import TraversableOnceExtension._
+
+  implicit class ArrayOps[A](val xs: Array[A]) extends AnyVal {
+
+    /**
+     * @see [[TraversableOnceOps.distinctBy]]
+     */
+    def distinctBy[B](f: A => B)(implicit ct: ClassTag[A]): Array[A] = (xs: Seq[A]).distinctBy(f).toArray
+
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/extensions/IteratorExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/IteratorExtension.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+object IteratorExtension {
+
+  implicit class IteratorOps[A](val iter: Iterator[A]) extends AnyVal {
+
+    /**
+     * A better version of <code>Iterator.copyToArray</code>,
+     * that returns the number of actually read elements.
+     *
+     * @param xs    the array to fill.
+     * @param start the starting index.
+     * @param len   the maximal number of elements to copy.
+     * @tparam B the type of the elements of the array.
+     * @note Reuse: $consumesIterator
+     */
+    def fetchToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
+      require(start >= 0 && (start < xs.length || xs.length == 0), s"start $start out of range ${xs.length}")
+      var i = start
+      val end = start + math.min(len, xs.length - start)
+      while (i < end && iter.hasNext) {
+        xs(i) = iter.next()
+        i += 1
+      }
+      i - start
+    }
+
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/extensions/NonOptionExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/NonOptionExtension.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import za.co.absa.commons.lang.TypeConstraints.not
+
+object NonOptionExtension {
+
+  implicit class NonOptionOps[A <: Any : not[Option[_]]#λ](a: A) {
+
+    def asOption: Option[A] = Option(a)
+
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/extensions/OptionExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/OptionExtension.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import scala.util.{Failure, Success, Try}
+
+object OptionExtension {
+
+  implicit class OptionOps[T](val option: Option[T]) extends AnyVal {
+
+    /**
+     * Converts Option to Try such that Some(x) becomes Success(x), and None becomes Failure(exception),
+     * where exception is provided as parameter.
+     *
+     * @param failure an Exception to use in Failure in case Option is None
+     * @return Try converted from Option
+     */
+    def toTry(failure: Exception): Try[T] =
+      option.fold[Try[T]](Failure(failure))(Success(_))
+
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/extensions/SeqExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/SeqExtension.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import scala.collection.mutable.ListBuffer
+
+object SeqExtension {
+  implicit class SeqOps[T](val seq: Seq[T]) extends AnyVal {
+
+    /**
+     * Collects consecutive items into groups if they have the same grouping value.
+     * A grouping value is provided by a callback function.
+     *
+     * It never groups `null` values.
+     *
+     * It is stable (does not change the original order of the elements).
+     *
+     * @param f A function that takes element of the sequence and returns its grouping value
+     * @return A sequence of groups
+     */
+    def groupConsecutiveBy[A](f: T => A): Seq[Seq[T]] = {
+      var lastElement: Option[A] = None
+      var group = new ListBuffer[T]
+      val groups = new ListBuffer[List[T]]
+
+      def pushGroup(): Unit = {
+        if (group.nonEmpty) {
+          groups += group.toList
+          group = new ListBuffer[T]
+        }
+      }
+
+      for (elem <- seq) {
+        val curGroupElement = f(elem)
+        lastElement match {
+          case Some(lastGroupElem) =>
+            if (curGroupElement == null || !curGroupElement.equals(lastGroupElem)) {
+              pushGroup()
+            }
+            group += elem
+          case None =>
+            pushGroup()
+            group += elem
+        }
+        lastElement = Option(curGroupElement)
+      }
+
+      pushGroup()
+      groups.toList
+    }
+
+    /**
+     * Collects consecutive items into groups if the predicate for all of them returns `true`.
+     * A predicate is provided by a callback function.
+     *
+     * It is stable (does not change the original order of the elements).
+     *
+     * @param p A predicate that should return `true` for each element that should be groped.
+     * @return A sequence of groups
+     */
+    def groupConsecutiveByPredicate(p: T => Boolean): Seq[Seq[T]] = {
+      val groupingValueFunction = (t: T) => p(t) match {
+        case false => NeverEquals
+        case true => true
+      }
+      groupConsecutiveBy(groupingValueFunction)
+    }
+
+    /**
+     * Collects consecutive items into groups if they have the same grouping value and that value is not None.
+     * A grouping value should be provided as an Option[T] by a callback function.
+     *
+     * It is stable (does not change the original order of the elements).
+     *
+     * @param f A function that takes element of the sequence and returns its grouping value as an Option
+     * @return A sequence of groups
+     */
+    def groupConsecutiveByOption[A](f: T => Option[A]): Seq[Seq[T]] = {
+      val groupingValueFunction = (a: T) => f(a).getOrElse(NeverEquals)
+      groupConsecutiveBy(groupingValueFunction)
+    }
+
+  }
+
+  private object NeverEquals {
+    override def equals(obj: Any): Boolean = false
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/extensions/StringExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/StringExtension.scala
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import java.security.InvalidParameterException
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+object StringExtension {
+
+  implicit class StringOps(val string: String) extends AnyVal {
+
+    /**
+     * Replaces all occurrences of the provided characters with their mapped values
+     *
+     * @param replacements the map of replacements where key's are chars to search for and values are their replacements
+     * @return a string with characters replaced
+     */
+    def replaceChars(replacements: Map[Char, Char]): String = {
+      if (replacements.isEmpty) {
+        string
+      } else {
+        val result = new mutable.StringBuilder(string.length)
+        string.foreach(char => result.append(replacements.getOrElse(char, char)))
+        result.toString
+      }
+    }
+
+    /**
+     * Function to find the first occurrence of any of the characters from the charsToFind in the string. The
+     * occurrence is not considered if the character is part of a sequence within a pair of quote characters specified
+     * by quoteChars param.
+     * Escape character in front of a quote character will cancel its "quoting" function.
+     * Escape character in front of a searched-for character will not result in positive identification of a find
+     * Double escape character is considered to be escape character itself, without its special meaning
+     * The escape character can be part of the charsToFind set or quoteChars set and the function will work as
+     * expected (e.g. double escape character being recognized as a searched-for character or quote character), but it
+     * cannot be both - that will fire an exception.
+     *
+     * @param charsToFind set of characters to look for
+     * @param quoteChars  set of characters that are considered as quotes, everything within two (same) quote characters
+     *                    is not considered
+     * @param escape      the special character to escape the expected behavior within string
+     * @return the index of the first find within the string, or None in case of no find
+     */
+    def findFirstUnquoted(charsToFind: Set[Char], quoteChars: Set[Char], escape: Char = '\\'): Option[Integer] = {
+      @tailrec
+      def scan(sub: String, idx: Integer, charToExitQuotes: Option[Char], escaped: Boolean = false): Option[Integer] = {
+        // escaped flag defaults to false, as every non-escape character clears it
+        val head = sub.headOption
+        (head, examineChar(head, charsToFind, quoteChars, escape, charToExitQuotes, escaped)) match {
+          case (None, _) => None // scanned the whole string without a hit
+          case (_, None) => Option(idx) // hit found
+          case (_, Some((nextCharToExitQuotes, nextEscaped))) =>
+            scan(sub.tail, idx + 1, nextCharToExitQuotes, nextEscaped) // continue search
+        }
+      }
+
+      checkInputsOverlap(charsToFind, quoteChars, escape: Char)
+      scan(string, 0, charToExitQuotes = None)
+    }
+
+    /**
+     * Function to check if any of the characters from the charsToFind occurs in the string.
+     * The occurrence is not considered if the character is part of a sequence within a pair of quote characters
+     * specified by quoteChars param.
+     * Escape character in front of a quote character will cancel its "quoting" function.
+     * Escape character in front of a searched-for character will not result in positive identification of a find
+     * Double escape character is considered to be escape character itself, without its special meaning
+     * The escape character can be part of the charsToFind set or quoteChars set and the function will work as
+     * expected (e.g. double escape character being recognized as a searched-for character or quote character), but it
+     * cannot be both - that will fire an exception.
+     *
+     * @param charsToFind set of characters to look for
+     * @param quoteChars  set of characters that are considered as quotes, everything within two (same) quote characters
+     *                    is not considered
+     * @param escape      the special character to escape the expected behavior within string
+     * @return true if anything is found, false otherwise
+     */
+    def hasUnquoted(charsToFind: Set[Char], quoteChars: Set[Char], escape: Char = '\\'): Boolean = {
+      findFirstUnquoted(charsToFind, quoteChars, escape).nonEmpty
+    }
+
+    /**
+     * Counts the occurrences of the chars to find. The occurrence is not considered if the character is part of a
+     * sequence within a pair of quote characters specified by quoteChars param.
+     * Escape character in front of a quote character will cancel its "quoting" function.
+     * Escape character in front of a searched-for character will not result in positive identification of a find
+     * Double escape character is considered to be escape character itself, without its special meaning
+     * The escape character can be part of the charsToFind set or quoteChars set and the function will work as
+     * expected (e.g. double escape character being recognized as a searched-for character or quote character), but it
+     * cannot be both - that will fire an exception.
+     *
+     * @param charsToFind set of characters to look for
+     * @param quoteChars  set of characters that are considered as quotes, everything within two (same) quote characters
+     *                    is not considered
+     * @param escape      the special character to escape the expected behavior within string
+     * @return map where charsToFind are the keys and values are the respective number of occurrences
+     */
+    def countUnquoted(charsToFind: Set[Char], quoteChars: Set[Char], escape: Char = '\\'): Map[Char, Int] = {
+      checkInputsOverlap(charsToFind, quoteChars, escape: Char)
+      val resultInit: Map[Char, Int] = charsToFind.map((_, 0)).toMap
+      val examineInit: (Option[Char], Boolean) = (Option.empty, false)
+      val (result, _) = string.foldLeft((resultInit, examineInit))((acc, char) => {
+        val (resultAcc, (charToExitQuotes, escaped)) = acc
+        val examineResult = examineChar(Option(char), charsToFind, quoteChars, escape, charToExitQuotes, escaped)
+        examineResult.map((resultAcc, _)) //no hit, propagate the examineResult
+          .getOrElse(resultAcc ++ Map(char -> (resultAcc(char) + 1)), examineInit)
+      })
+      result
+    }
+
+    /**
+     * Joins two strings with / while stripping single existing trailing/leading "/" in between:
+     * {{{
+     * "abc" / "123" -> "abc/123"
+     * "abc/" / "123" -> "abc/123"
+     * "abc" / "/123" -> "abc/123"
+     * "abc/" / "/123" -> "abc/123",
+     * but:
+     * "file:///" / "path" -> "file:///path",
+     * }}}
+     *
+     * @param another the second string we are appending after the `/` separator
+     * @return this/another (this has stripped trailing / if present, another has leading / stripped if present)
+     */
+    def /(another: String): String = { // scalastyle:ignore method.name
+      joinWithSingleSeparator(another, "/")
+    }
+
+    /**
+     * Function to check if string is empty, if that is the case it returns default, otherwise the string itself.
+     *
+     * @param default string to use in case of emptiness
+     * @return default if string is nonempty, the string otherwise
+     */
+    def nonEmptyOrElse(default: => String): String = {
+      if (string.isEmpty) default else string
+    }
+
+    /**
+     * Gets first nonempty string from collection consisting of this string and alternatives.
+     * This string has the highest priority, then the leftmost alternative, then next alternative to the right, etc.
+     *
+     * @example "".coalesce("abc", "cde")     // -> "abc"
+     * @example "123".coalesce("abc", "cde")  // -> "123"
+     * @example "".coalesce("", "cde", "efg") // -> "cde"
+     * @param alternatives strings that are used in case of emptiness
+     * @return first nonempty string (if there is any)
+     */
+    def coalesce(alternatives: String*): String = {
+      alternatives.foldLeft(string)(_.nonEmptyOrElse(_))
+    }
+
+    private[lang] def joinWithSingleSeparator(another: String, sep: String): String = {
+      val sb = new mutable.StringBuilder
+      sb.append(string.stripSuffix(sep))
+      sb.append(sep)
+      sb.append(another.stripPrefix(sep))
+      sb.mkString
+    }
+
+    /**
+     * Investigates if the character in the relation to previous characters and charsToFind
+     *
+     * @param char             character to examine, for easier matching and also support end of string, it's an Option
+     * @param charsToFind      set of characters to look for
+     * @param quoteChars       set of characters that are considered as quotes, everything within two (same) quote characters
+     *                         is not considered
+     * @param escape           the special character to escape the expected behavior within string
+     * @param charToExitQuotes character that would is awaited to exit the "quotes"; if not empty means scan is within
+     *                         "quotes"
+     * @param escaped          if true the previous character was the escape character
+     * @return Optional 2-tuple, None means hit (char is one of the charsToFind), otherwise it's the value of
+     *         charToExitQuotes and escaped for the next character
+     */
+    private def examineChar(char: Option[Char],
+                            charsToFind: Set[Char],
+                            quoteChars: Set[Char],
+                            escape: Char,
+                            charToExitQuotes: Option[Char],
+                            escaped: Boolean = false): Option[(Option[Char], Boolean)] = {
+      (char, escaped) match {
+        // no more chars on input probably
+        case (None, _) => Option(None, false)
+        // following cases are to address situations when the char character is within quotes (not yet closed)
+        // exit quote unless it's escaped or is the escape character itself
+        case (`charToExitQuotes`, false) if !charToExitQuotes.contains(escape) => Option(None, false)
+        // escaped exit quote means exit only if it's the escape character itself
+        case (`charToExitQuotes`, true) if charToExitQuotes.contains(escape) => Option(None, false)
+        // escape charter found (not necessary withing quotes, but has to be handled it this order)
+        case (Some(`escape`), false) => Option(charToExitQuotes, true)
+        // any other character within quotes, no special case
+        case _ if charToExitQuotes.nonEmpty => Option(charToExitQuotes, false)
+        // following cases addresses situations when the char character is outside quotes
+        // escaped escape character if it's also a quote character
+        case (Some(`escape`), true) if quoteChars.contains(escape) => Option(Option(escape), false)
+        //escaped escape character if it's also a character to find
+        case (Some(`escape`), true) if charsToFind.contains(escape) => None
+        // entering quotes
+        case (Some(c), false) if quoteChars.contains(c) => Option(Option(c), false)
+        // found one of the characters to search for
+        case (Some(c), false) if charsToFind.contains(c) => None
+        // an escaped quote character that is also within the characters to find
+        case (Some(c), true) if quoteChars.contains(c) && charsToFind.contains(c) => None
+        // all other cases, continue scan
+        case _ => Option(None, false)
+      }
+    }
+
+    private def checkInputsOverlap(charsToFind: Set[Char], quoteChars: Set[Char], escape: Char = '\\'): Unit = {
+      if (charsToFind.contains(escape) && quoteChars.contains(escape)) {
+        throw new InvalidParameterException(
+          s"Escape character '$escape 'is both between charsToFind and quoteChars. That's not allowed."
+        )
+      }
+    }
+
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/extensions/StringExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/StringExtension.scala
@@ -166,6 +166,17 @@ object StringExtension {
       alternatives.foldLeft(string)(_.nonEmptyOrElse(_))
     }
 
+    /**
+     * Converts string into Option by returning
+     * Some(string) in case string is not null and contains any non-whitespace characters, None otherwise.
+     *
+     * @return Option containing string if its is non blank
+     */
+    def nonBlankOption: Option[String] =
+      if (string == null) None
+      else if (string.trim.isEmpty) None
+      else Some(string)
+
     private[lang] def joinWithSingleSeparator(another: String, sep: String): String = {
       val sb = new mutable.StringBuilder
       sb.append(string.stripSuffix(sep))

--- a/src/main/scala/za/co/absa/commons/lang/extensions/TraversableExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/TraversableExtension.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+object TraversableExtension {
+
+  implicit class TraversableOps[A <: Traversable[_]](val xs: A) extends AnyVal {
+
+    def asOption: Option[A] = if (xs.isEmpty) None else Some(xs)
+
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/lang/extensions/TraversableOnceExtension.scala
+++ b/src/main/scala/za/co/absa/commons/lang/extensions/TraversableOnceExtension.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
+
+object TraversableOnceExtension {
+
+  implicit class TraversableOnceOps[A, M[X] <: TraversableOnce[X]](val xs: M[A]) extends AnyVal {
+
+    /**
+     * Almost like `distinct`, but instead of comparing elements itself it compares their projections,
+     * returned by a given function `f`.
+     *
+     * It's logically equivalent to doing stable grouping by `f` followed by selecting the first value of each key.
+     *
+     * @param f   projection function
+     * @param cbf collection builder factory
+     * @return a new sequence of elements which projection (obtained by applying the function `f`)
+     *         are the first occurrence of every other elements' projection of this sequence.
+     */
+    def distinctBy[B](f: A => B)(implicit cbf: CanBuildFrom[M[A], A, M[A]]): M[A] = {
+      val seen = mutable.Set.empty[B]
+      val b = cbf(xs)
+      for (x <- xs) {
+        val y = f(x)
+        if (!seen(y)) {
+          b += x
+          seen += y
+        }
+      }
+      b.result()
+    }
+
+  }
+
+}

--- a/src/main/scala/za/co/absa/commons/parsers/UrisConnectionStringParser.scala
+++ b/src/main/scala/za/co/absa/commons/parsers/UrisConnectionStringParser.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.parsers
+
+object UrisConnectionStringParser {
+
+  private val hostsRegex = """^\s*http(?:s)?://([^\s]+?)(?:/[^\s]*)?\s*$""".r
+
+  /**
+   * Parses a connection string containing one or multiple URIs into a list of strings (each being one URI).
+   * Input URIs are supposed to have semi-colon-separated base URIs, and each can have multiple comma-separated hosts.
+   *
+   * @example parse("https://localhost:8080,host2:8080/rest_api;http://localhost:9000/rest_api") ->
+   *          List("https://localhost:8080/rest_api", "https://host2:8080/rest_api", "http://localhost:9000/rest_api")
+   *
+   * @param connectionString string containing semi-colon separated base URIs with comma-separated hosts
+   * @return a list of parsed URIs
+   */
+  @throws[IllegalArgumentException]
+  def parse(connectionString: String): List[String] = {
+    connectionString
+      .split(";")
+      .flatMap(expandHosts)
+      .map(_.trim
+        .replaceAll("/$", "")
+      )
+      .distinct
+      .toList
+  }
+
+  private def expandHosts(multiHostUrl: String): Array[String] = {
+    multiHostUrl match {
+      case hostsRegex(hosts) =>
+        hosts.split(",").map { host =>
+          multiHostUrl.replace(hosts, host)
+        }
+      case _ =>
+        throw new IllegalArgumentException("Malformed connection string")
+    }
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/lang/extensions/AnyExtensionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/extensions/AnyExtensionSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import org.mockito.Mockito
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+class AnyExtensionSpec extends AnyFunSpec with Matchers with MockitoSugar {
+
+  import AnyExtension._
+
+  describe("AnyOps") {
+    describe("optionally()") {
+
+      it("should do nothing when maybeArg is None") {
+        val aString = "abc"
+        val aInt = 1
+        val aList = List(1, 2, 3)
+
+        aString.optionally[Float]((s, b) => b.toString, None) shouldEqual aString
+        aInt.optionally[Float]((i, b) => b.toInt, None) shouldEqual aInt
+        aList.optionally[Float]((l, b) => List(b.toInt), None) shouldEqual aList
+      }
+
+      it("should not call applyFn when maybeArg is None") {
+        val aString = "abc"
+        val applyFn = mock[(String, Float) => String]
+
+        aString.optionally[Float](applyFn, None)
+
+        Mockito.verifyNoInteractions(applyFn)
+      }
+
+      it("should return result of applied applyFn when maybeArg is not None") {
+        val aString = "abc"
+        val aInt = 1
+        val aList = List(1, 2, 3)
+
+        aString.optionally[Float]((s, b) => b.toString, Some(0.0F)) shouldEqual "0.0"
+        aInt.optionally[Float]((i, b) => b.toInt, Some(0.0F)) shouldEqual 0
+        aList.optionally[Float]((l, b) => List(b.toInt), Some(5.0F)) shouldEqual List(5)
+      }
+
+    }
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/lang/extensions/ArrayExtensionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/extensions/ArrayExtensionSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import org.mockito.Mockito
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+class ArrayExtensionSpec extends AnyFunSpec with Matchers with MockitoSugar {
+
+  import ArrayExtension._
+
+  describe("ArrayOps") {
+    describe("distinctBy()") {
+
+      it("should create a new instance of empty array when called on empty array") {
+        val dummyFn = mock[Unit => _]
+        val originalArr = Array.empty[Unit]
+        val distinctArr = originalArr.distinctBy(dummyFn)
+
+        distinctArr should not(be theSameInstanceAs originalArr)
+        distinctArr should have length 0
+        Mockito.verifyNoInteractions(dummyFn)
+      }
+
+      it("should eliminate duplicates on identity projection") {
+        val arr = Array(1, 2, 1)
+
+        val duplicatesEliminated = arr.distinctBy(identity)
+
+        duplicatesEliminated shouldEqual Array(1, 2)
+      }
+
+      it("should eliminate duplicates on custom projection") {
+        val arr = Array(1, 2, 1, 0, 3)
+
+        val duplicatesEliminated = arr.distinctBy(x => x % 2)
+
+        duplicatesEliminated shouldEqual Array(1, 2)
+      }
+
+    }
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/lang/extensions/IteratorExtensionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/extensions/IteratorExtensionSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+class IteratorExtensionSpec extends AnyFunSpec with Matchers with MockitoSugar {
+
+  import IteratorExtension._
+
+  describe("IteratorOps") {
+
+    describe("fetchToArray()") {
+
+      it("should fill the array") {
+        val arr = Array.ofDim[Char](5)
+        val iter = "abcdefghijklmnopqrstuvwxyz".iterator
+
+        val cnt = iter.fetchToArray(arr, 0, 5)
+
+        cnt should be(5)
+        arr shouldEqual "abcde".toArray
+        iter should have length 21
+      }
+
+      it("should copy a range of items into an array") {
+        val arr = Array.ofDim[Char](5)
+        val iter = "abcdefghijklmnopqrstuvwxyz".iterator
+
+        val cnt = iter.fetchToArray(arr, 1, 3)
+
+        cnt should be(3)
+        arr shouldEqual Array(0, 'a', 'b', 'c', 0)
+        iter should have length 23
+      }
+
+      it("should exhaust the iterator if one has not enough items") {
+        val arr = Array.ofDim[Char](5)
+        val iter = "a".iterator
+
+        val cnt = iter.fetchToArray(arr, 1, 3)
+
+        cnt should be(1)
+        arr shouldEqual Array(0, 'a', 0, 0, 0)
+        iter should be(empty)
+      }
+
+      it("should not overfill the array") {
+        val arr = Array.ofDim[Char](5)
+        val iter = "abcdefghijklmnopqrstuvwxyz".iterator
+
+        val cnt = iter.fetchToArray(arr, 1, 99)
+
+        cnt should be(4)
+        arr shouldEqual Array(0, 'a', 'b', 'c', 'd')
+        iter should have length 22
+      }
+
+      it("should do nothing on empty range") {
+        val arr = Array.ofDim[Char](5)
+        val iter = "abcdefghijklmnopqrstuvwxyz".iterator
+
+        val cnt = iter.fetchToArray(arr, 1, 0)
+
+        cnt should be(0)
+        all(arr) should be(0)
+        iter should have length 26
+      }
+
+      it("should do nothing on empty iterators") {
+        val arr = Array.ofDim[Char](5)
+        val cnt = Iterator[Char]().fetchToArray(arr, 1, 3)
+        cnt should be(0)
+        all(arr) should be(0)
+      }
+
+      it("should throw on incorrect array bounds") {
+        val arr = Array.ofDim[Char](5)
+        intercept[IllegalArgumentException](Iterator[Char]().fetchToArray(arr, 5, 0))
+        intercept[IllegalArgumentException](Iterator[Char]().fetchToArray(arr, -1, 0))
+      }
+    }
+
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/lang/extensions/OptionExtensionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/extensions/OptionExtensionSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.lang.extensions.OptionExtension.OptionOps
+
+import scala.util.{Failure, Success}
+
+class OptionExtensionSpec extends AnyFunSuite with Matchers {
+
+  test("OptionOps.toTry - case Some") {
+    val option = Some("abc")
+    val expected = Success("abc")
+
+    val actual = option.toTry(new Exception)
+
+    assert(expected == actual)
+  }
+
+  test("OptionOps.toTry - case None") {
+    val option = None
+
+    val result = option.toTry(new Exception("exception occurred"))
+
+    assert(result.isFailure)
+    assert(result match { case Failure(e) => e.getMessage == "exception occurred" })
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/lang/extensions/SeqExtensionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/extensions/SeqExtensionSpec.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class SeqExtensionSpec extends AnyFunSuite with Matchers {
+
+  import za.co.absa.commons.lang.extensions.SeqExtension._
+
+  case class Person(firstName: String, lastName: String)
+
+  private val people = Seq(Person("Andrew", "Mikels"), Person("Andrew", "Gross"),
+    Person("Rosetta", "Best"), Person("Julieta", "Guess"),
+    Person("Julieta", "Griffey"), Person("Kaitlin", "Griffey"),
+    Person("Allison", "Griffey"), Person("Allison", "Brooks")
+  )
+
+  private val peopleExpectGroupByFirstNames = Seq(Seq(Person("Andrew", "Mikels"), Person("Andrew", "Gross")),
+    Seq(Person("Rosetta", "Best")), Seq(Person("Julieta", "Guess"),
+      Person("Julieta", "Griffey")), Seq(Person("Kaitlin", "Griffey")),
+    Seq(Person("Allison", "Griffey"), Person("Allison", "Brooks"))
+  )
+
+  private val peopleExpectGroupByLastNames = Seq(Seq(Person("Andrew", "Mikels")), Seq(Person("Andrew", "Gross")),
+    Seq(Person("Rosetta", "Best")), Seq(Person("Julieta", "Guess")),
+    Seq(Person("Julieta", "Griffey"), Person("Kaitlin", "Griffey"),
+      Person("Allison", "Griffey")), Seq(Person("Allison", "Brooks"))
+  )
+
+  test("SeqOps.groupConsecutiveBy - grouping values in the middle") {
+    val numbers = Seq(1, 2, 2, 2, 1)
+    val expected = Seq(Seq(1), Seq(2, 2, 2), Seq(1))
+
+    val actual = numbers.groupConsecutiveBy[Int](a => a)
+
+    assert(actual == expected)
+  }
+
+  test("SeqOps.groupConsecutiveBy - grouping several groups") {
+    val numbers = Seq(1, 1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 1, 1)
+    val expected = Seq(Seq(1, 1, 1), Seq(2, 2), Seq(3, 3), Seq(1, 1), Seq(2, 2), Seq(1, 1))
+
+    val actual = numbers.groupConsecutiveBy[Int](a => a)
+
+    assert(actual == expected)
+  }
+
+  test("SeqOps.groupConsecutiveBy - should not group nulls") {
+    val numbers: Seq[Integer] = Seq(1, 1, 1, null, null, 3, 3, 1, 1, null, null, 1, 1) // scalastyle:ignore null
+    val expected = Seq(Seq(1, 1, 1), Seq(null), Seq(null), Seq(3, 3), Seq(1, 1), Seq(null), Seq(null), Seq(1, 1)) // scalastyle:ignore null
+    val actual = numbers.groupConsecutiveBy[Integer](a => a)
+
+    assert(actual == expected)
+  }
+
+  test("SeqOps.groupConsecutiveBy - handling non-primitive types") {
+    val actualFirstNames = people.groupConsecutiveBy[String](a => a.firstName)
+    val actualLastNames = people.groupConsecutiveBy[String](a => a.lastName)
+
+    assert(actualFirstNames == peopleExpectGroupByFirstNames)
+    assert(actualLastNames == peopleExpectGroupByLastNames)
+  }
+
+  test("SeqOps.groupConsecutiveByPredicate - non grouping individual values") {
+    val numbers = Seq(1, 2, 3, 1, 2, 3, 1)
+    val expected = Seq(Seq(1), Seq(2), Seq(3), Seq(1), Seq(2), Seq(3), Seq(1))
+
+    val actual = numbers.groupConsecutiveByPredicate(a => a == 1)
+
+    assert(actual == expected)
+  }
+
+  test("SeqOps.groupConsecutiveByPredicate - handling a group of strings") {
+    val strings = Seq("foo", "bar", "foo", "foo", "bar")
+    val expected = Seq(Seq("foo"), Seq("bar"), Seq("foo", "foo"), Seq("bar"))
+
+    val actual = strings.groupConsecutiveByPredicate(a => a == "foo")
+
+    assert(actual == expected)
+  }
+
+  test("SeqOps.groupConsecutiveByPredicate - handling a non-primitive type") {
+    val actual = people.groupConsecutiveByPredicate(a => a.lastName == "Griffey")
+
+    assert(actual == peopleExpectGroupByLastNames)
+  }
+
+  test("SeqOps.groupConsecutiveByPredicate - grouping values in the beginning and at the end") {
+    val numbers = Seq(1, 1, 1, 2, 2, 1, 1, 3, 3, 1, 1)
+    val expected = Seq(Seq(1, 1, 1), Seq(2), Seq(2), Seq(1, 1), Seq(3), Seq(3), Seq(1, 1))
+
+    val actual = numbers.groupConsecutiveByPredicate(a => a == 1)
+
+    assert(actual == expected)
+  }
+
+
+  test("SeqOps.groupConsecutiveByOption - grouping values in the middle") {
+    val numbers = Seq(1, 2, 2, 2, 1)
+    val expected = Seq(Seq(1), Seq(2, 2, 2), Seq(1))
+
+    val actual = numbers.groupConsecutiveByOption[Int](a => Some(a))
+
+    assert(actual == expected)
+  }
+
+  test("SeqOps.groupConsecutiveByOption - grouping only Some(x)") {
+    val numbers = Seq(1, 1, 1, 2, 2, 3, 3, 1, 1, 2, 2, 1, 1)
+    val expected = Seq(Seq(1, 1, 1), Seq(2), Seq(2), Seq(3), Seq(3), Seq(1, 1), Seq(2), Seq(2), Seq(1, 1))
+
+    val actual = numbers.groupConsecutiveByOption[Int](a => if (a == 1) Some(a) else None)
+
+    assert(actual == expected)
+  }
+
+  test("SeqOps.groupConsecutiveByOption - handling non-primitive types") {
+    val actualFirstNames = people.groupConsecutiveByOption[String](a => Some(a.firstName))
+    val actualLastNames = people.groupConsecutiveByOption[String](a => Some(a.lastName))
+
+    assert(actualFirstNames == peopleExpectGroupByFirstNames)
+    assert(actualLastNames == peopleExpectGroupByLastNames)
+  }
+}

--- a/src/test/scala/za/co/absa/commons/lang/extensions/StringExtensionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/extensions/StringExtensionSpec.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.commons.lang.extensions.StringExtension.StringOps
+
+import java.security.InvalidParameterException
+
+class StringExtensionSpec extends AnyFunSuite with Matchers {
+  test("StringOps.replaceChars - empty replacements") {
+    val s = "supercalifragilisticexpialidocious"
+    assert(s.replaceChars(Map.empty) == s)
+  }
+
+  test("StringOps.replaceChars - no hits") {
+    val s = "supercalifragilisticexpialidocious"
+    val map = Map('1' -> '5', '2' -> '6', '3' -> '7')
+    assert(s.replaceChars(map) == s)
+  }
+
+  test("StringOps.replaceChars - replace all to same char") {
+    val s: String = "abcba"
+    val map = Map('a' -> 'x', 'b' -> 'x', 'c' -> 'x', 'd' -> 'x')
+    assert(s.replaceChars(map) == "xxxxx")
+  }
+
+  test("StringOps.replaceChars - swap characters") {
+    val s: String = "abcba"
+    val map = Map('a' -> 'b', 'b' -> 'a')
+    assert(s.replaceChars(map) == "bacab")
+  }
+
+  test("StringOps.findFirstUnquoted - empty string") {
+    var result = "".findFirstUnquoted(Set.empty, Set.empty)
+    assert(result.isEmpty)
+    result = "".findFirstUnquoted(Set('a'), Set.empty)
+    assert(result.isEmpty)
+    result = "".findFirstUnquoted(Set('a', 'b', 'c'), Set('\''))
+    assert(result.isEmpty)
+    result = "".findFirstUnquoted(Set('a', 'b', 'c'), Set('\'', '"'))
+    assert(result.isEmpty)
+  }
+
+  test("StringOps.findFirstUnquoted - no quotes") {
+    var result = "Hello world".findFirstUnquoted(Set('x', 'y', 'z'), Set.empty)
+    assert(result.isEmpty)
+    result = "Hello world".findFirstUnquoted(Set('w'), Set.empty)
+    assert(result.contains(6))
+    result = "Hello world".findFirstUnquoted(Set('w', 'e', 'l'), Set.empty)
+    assert(result.contains(1))
+  }
+
+  test("StringOps.findFirstUnquoted - simple quotes") {
+    val quotes = Set('\'')
+    var result = "Hello 'world'".findFirstUnquoted(Set('w'), quotes)
+    assert(result.isEmpty)
+    result = "Hello 'world'".findFirstUnquoted(Set('w', 'e', 'l'), quotes)
+    assert(result.contains(1))
+    result = "'Hello' world".findFirstUnquoted(Set('w', 'e', 'l'), quotes)
+    assert(result.contains(8))
+  }
+
+  test("StringOps.findFirstUnquoted - multiple quotes") {
+    val charsToFind = Set('w', 'e', 'l')
+    val quotes = Set('\'', '`')
+    var result = "`Hello` 'world'".findFirstUnquoted(charsToFind, quotes)
+    assert(result.isEmpty)
+    result = "`Hello` 'wor'ld".findFirstUnquoted(charsToFind, quotes)
+    assert(result.contains(13))
+    result = "`Hel'lo` 'wor'ld".findFirstUnquoted(charsToFind, quotes)
+    assert(result.contains(14))
+  }
+
+  test("StringOps.findFirstUnquoted - using escape character") {
+    val charsToFind = Set('w', 'e', 'l')
+    val quotes = Set('\'', '`')
+    var result = "`Hello` \\'world".findFirstUnquoted(charsToFind, quotes) //hasn't started
+    assert(result.contains(10))
+    result = "`H\\`ello` 'wor\'ld".findFirstUnquoted(charsToFind, quotes) //hasn't ended
+    assert(result.contains(15))
+    result = "`Hello\\`` 'wor'ld".findFirstUnquoted(charsToFind, quotes) //escaped followed by unescaped
+    assert(result.contains(15))
+    result = "\\ `Hello` 'world'".findFirstUnquoted(charsToFind, quotes) //escape elsewhere
+    assert(result.isEmpty)
+    result = "H\\e\\l\\lo \\wor\\ld'".findFirstUnquoted(charsToFind, quotes) //hits escaped
+    assert(result.isEmpty)
+  }
+
+  test("StringOps.findFirstUnquoted - quote between search characters") {
+    val charsToFind = Set('w', 'e', 'l', '\'')
+    val quotes = Set('\'', '`')
+    var result = "Hello \\'world".findFirstUnquoted(charsToFind, quotes) //simple
+    assert(result.contains(1))
+    result = "`Hello` \\'world".findFirstUnquoted(charsToFind, quotes) //quote hit
+    assert(result.contains(9))
+    result = "`Hello` 'world'".findFirstUnquoted(charsToFind, quotes) //just quotes
+    assert(result.isEmpty)
+    result = "`Hello\\'` 'world'".findFirstUnquoted(charsToFind, quotes) //within other quotes
+    assert(result.isEmpty)
+    result = "`Hello` '\\'world'".findFirstUnquoted(charsToFind, quotes) //within same quotes
+    assert(result.isEmpty)
+  }
+
+  test("StringOps.findFirstUnquoted - custom escape character") {
+    val charsToFind = Set('w', 'e', 'l')
+    val quotes = Set('\'', '`')
+    val escapeChar = '~'
+    var result = "`Hello` ~'world".findFirstUnquoted(charsToFind, quotes, escapeChar) //hasn't started
+    assert(result.contains(10))
+    result = "`H~`ello` 'wor'ld".findFirstUnquoted(charsToFind, quotes, escapeChar) //hasn't ended
+    assert(result.contains(15))
+    result = "`Hello~`` 'wor'ld".findFirstUnquoted(charsToFind, quotes, escapeChar) //escaped followed by unescaped
+    assert(result.contains(15))
+    result = "~ `Hello` 'world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //escape elsewhere
+    assert(result.isEmpty)
+    result = "`Hello~`` 'wor'\\ld".findFirstUnquoted(charsToFind, quotes, escapeChar) //mix-in standard escape
+    assert(result.contains(16))
+  }
+
+  test("StringOps.findFirstUnquoted - many escapes") { //better to do with other then \
+    val charsToFind = Set('w')
+    val quotes = Set('\'')
+    val escapeChar = '~'
+    var result = "Hello ~~world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //escaped escape -> hit valid
+    assert(result.contains(8))
+    result = "Hello ~~'world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //escaped escape -> quotes valid
+    assert(result.isEmpty)
+    result = "Hello ~~~world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //3x -> hit escaped
+    assert(result.isEmpty)
+    result = "Hello ~~~'world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //3x -> quote escaped
+    assert(result.contains(10))
+    result = "'Hello ~~~~~'world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //5x -> quote escaped, whole string quoted
+    assert(result.isEmpty)
+  }
+
+  test("StringOps.findFirstUnquoted - escape in search chars") { //better to do with other then \
+    val escapeChar = '~'
+    val quotes = Set('\'')
+    val charsToFind = Set('w', escapeChar)
+    var result = "Hello ~~world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //escaped escape -> hit valid
+    assert(result.contains(7))
+    result = "Hello '~~world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //escaped escape in quotes
+    assert(result.isEmpty)
+    result = "Hello ~'~~world".findFirstUnquoted(charsToFind, quotes, escapeChar) //escaped quote
+    assert(result.contains(9))
+    result = "Hello ~world~~".findFirstUnquoted(charsToFind, quotes, escapeChar) //escaped normal hit, escaped escape follows
+    assert(result.contains(13))
+  }
+
+  test("StringOps.findFirstUnquoted - escape in quote chars") { //better to do with other then \
+    val escapeChar = '~'
+    val quotes = Set('\'', escapeChar)
+    val charsToFind = Set('w', 'e', 'l')
+    var result = "~'Hello world'".findFirstUnquoted(charsToFind, quotes, escapeChar) //simple escape
+    assert(result.contains(3))
+    result = "~~Hello ~~pole".findFirstUnquoted(charsToFind, quotes, escapeChar) //escape as quotes
+    assert(result.contains(12))
+    result = "~~Hello ~~'pole'".findFirstUnquoted(charsToFind, quotes, escapeChar) //escape as quotes followed by standard quotes
+    assert(result.isEmpty)
+    result = "~~Hello ~~world".findFirstUnquoted(charsToFind, quotes, escapeChar) //escape as quotes directly followed by hit
+    assert(result.contains(10))
+    result = "~~Hello ~~~world".findFirstUnquoted(charsToFind, quotes, escapeChar) //escape as quotes and right after escaped hit
+    assert(result.contains(14))
+  }
+
+  test("StringOps.findFirstUnquoted - escape in search and quote chars") { //better to do with other then \
+    val escapeChar = '!'
+    val quotes = Set('\'', escapeChar)
+    val charsToFind = Set('w', 'e', 'l', escapeChar)
+    val expectedMessage = s"Escape character '$escapeChar 'is both between charsToFind and quoteChars. That's not allowed."
+    val caught = intercept[InvalidParameterException] {
+      "All the jewels of the world!".findFirstUnquoted(charsToFind, quotes, escapeChar)
+    }
+    assert(caught.getMessage == expectedMessage)
+  }
+
+  test("StringOps.hasUnquoted") {
+    assert(!"".hasUnquoted(Set.empty, Set.empty))
+    assert(!"Hello world".hasUnquoted(Set('x'), Set.empty))
+    assert("Hello world".hasUnquoted(Set('w', 'e', 'l'), Set('`')))
+    assert(!"`Hello world`".hasUnquoted(Set('w', 'e', 'l'), Set('`')))
+  }
+
+  test("StringOps.countUnquoted: empty variants") {
+    val expected = Map(
+      'x'->0,
+      'y'->0,
+      'z'->0
+    )
+    val charsToFind = Set('x', 'y', 'z')
+    val empty = Set.empty[Char]
+    assert("".countUnquoted(charsToFind, Set('"')) == expected)
+    assert("Lorem ipsum".countUnquoted(charsToFind, empty) == expected)
+    assert("Hello world".countUnquoted(empty, Set('|')) == Map.empty)
+  }
+
+  test("StringOps.countUnquoted: simple test") {
+    val charsToFind = Set('x', 'y', 'z')
+    val expected1 = Map(
+      'x'->0,
+      'y'->0,
+      'z'->0
+    )
+    assert("Lorem ipsum".countUnquoted(charsToFind, Set('\'')) == expected1)
+    assert("Hello 'xyz' world".countUnquoted(charsToFind, Set('\'')) == expected1)
+    val expected2 = Map(
+      'x'->3,
+      'y'->2,
+      'z'->1
+    )
+    assert("xxxyzy".countUnquoted(charsToFind, Set('-')) == expected2)
+    val expected3 = Map(
+      'x'->1,
+      'y'->2,
+      'z'->5
+    )
+    assert("x-xxy-yyzzz|zyyy|zz".countUnquoted(charsToFind, Set('-', '|')) == expected3)
+  }
+
+  test("StringOps.countUnquoted: escape involved") {
+    val charsToFind = Set('x', 'y', 'z')
+    val expected = Map(
+      'x'->3,
+      'y'->2,
+      'z'->3
+    )
+    assert("x~yz~'xxyyzz 'xxxx~'zzzz'~''yyyy".countUnquoted(charsToFind, Set('\''),'~') == expected)
+  }
+
+  test("StringOps.countUnquoted: search and quote chars overlap") {
+    val charsToFind = Set('a', '#', '$', '%')
+    val quoteChars = Set('$', '%', '^')
+    val expected = Map(
+      'a'->0,
+      '#'->1,
+      '$'->1,
+      '%'->0
+    )
+    assert("#^##^|$%%%%".countUnquoted(charsToFind, quoteChars, '|') == expected)
+  }
+
+  test("StringOps.countUnquoted: escape in search for chars") {
+    val charsToFind = Set('a', 'b', 'c', 'd', '|')
+    val quoteChars = Set('%', '^')
+    val expected = Map(
+      'a'->2,
+      'b'->0,
+      'c'->2,
+      'd'->0,
+      '|'->1
+    )
+    assert("aa||%bb%|^cc^a|cd||d|^b^".countUnquoted(charsToFind, quoteChars, '|') == expected)
+  }
+
+  test("StringOps.countUnquoted: escape in quote chars") {
+    val charsToFind = Set('a', 'b', 'c')
+    val quoteChars = Set('$', '%', '^')
+    val expected = Map(
+      'a'->1,
+      'b'->0,
+      'c'->0
+    )
+    assert("a$$bc$$".countUnquoted(charsToFind, quoteChars, '$') == expected)
+  }
+
+  test("StringOps.joinWithSingleSeparator: string joining general") {
+    "abc#".joinWithSingleSeparator("#def", "#") shouldBe "abc#def"
+    "abc###".joinWithSingleSeparator("def", "#") shouldBe "abc###def"
+    "abcSEP".joinWithSingleSeparator("def", "SEP") shouldBe "abcSEPdef"
+    "abcSEPSEP".joinWithSingleSeparator("SEPSEPdef", "SEP") shouldBe "abcSEPSEPSEPdef"
+  }
+
+  test("StringOps./: string joining with /") {
+    "abc" / "123" shouldBe "abc/123"
+    "aaa/" / "123" shouldBe "aaa/123"
+    "bbb" / "/123" shouldBe "bbb/123"
+    "ccc/" / "/123" shouldBe "ccc/123"
+    "file:///" / "path" shouldBe "file:///path"
+  }
+
+  test("StringOps.nonEmptyOrElse") {
+    "a".nonEmptyOrElse("b") shouldBe "a"
+    "".nonEmptyOrElse("b") shouldBe "b"
+    "a".nonEmptyOrElse("") shouldBe "a"
+  }
+
+  test("StringOps.coalesce") {
+    "".coalesce() shouldBe ""
+    "".coalesce("A", "") shouldBe "A"
+    "".coalesce("", "", "B", "", "C") shouldBe "B"
+    "X".coalesce("Y", "Z") shouldBe "X"
+    "X".coalesce("") shouldBe "X"
+  }
+
+}
+

--- a/src/test/scala/za/co/absa/commons/lang/extensions/StringExtensionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/extensions/StringExtensionSpec.scala
@@ -308,5 +308,17 @@ class StringExtensionSpec extends AnyFunSuite with Matchers {
     "X".coalesce("") shouldBe "X"
   }
 
+  test("StringOps.nonBlankOption - for blank string") {
+    (null: String).nonBlankOption should be(None)
+    "            ".nonBlankOption should be(None)
+  }
+
+  test("StringOps.nonBlankOption - for non blank string") {
+    " foo bar 42 ".nonBlankOption should be(Some(" foo bar 42 "))
+    "     .".nonBlankOption should be(Some("     ."))
+    ".      ".nonBlankOption should be(Some(".      "))
+    "     .      ".nonBlankOption should be(Some("     .      "))
+  }
+
 }
 

--- a/src/test/scala/za/co/absa/commons/lang/extensions/TraversableOnceExtensionSpec.scala
+++ b/src/test/scala/za/co/absa/commons/lang/extensions/TraversableOnceExtensionSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.lang.extensions
+
+import org.mockito.Mockito
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.collection.mutable
+
+class TraversableOnceExtensionSpec extends AnyFunSpec with Matchers with MockitoSugar {
+
+  import TraversableOnceExtension._
+
+  describe("TraversableOnceOps") {
+    describe("distinctBy()") {
+
+      it("should do nothing on empty immutable collections") {
+        val dummyFn = mock[Unit => _]
+        Seq.empty[Unit].distinctBy(dummyFn) should be theSameInstanceAs Seq.empty
+        Mockito.verifyNoInteractions(dummyFn)
+      }
+
+      it("should create a new instance of empty mutable collections") {
+        val dummyFn = mock[Unit => _]
+        val originalCol = mutable.Seq.empty[Unit]
+        val distinctCol = originalCol.distinctBy(dummyFn)
+
+        distinctCol should not(be theSameInstanceAs originalCol)
+        distinctCol should have length 0
+        Mockito.verifyNoInteractions(dummyFn)
+      }
+
+      it("should return the same collection type as it was called on") {
+        // immutable
+        Seq(1, 2).distinctBy(identity) should be(a[Seq[_]])
+        List(1, 2).distinctBy(identity) should be(a[List[_]])
+        Vector(1, 2).distinctBy(identity) should be(a[Vector[_]])
+        Set(1, 2).distinctBy(identity) should be(a[Set[_]])
+        // mutable
+        mutable.Seq(1, 2).distinctBy(identity) should be(a[mutable.Seq[_]])
+        mutable.ListBuffer(1, 2).distinctBy(identity) should be(a[mutable.ListBuffer[_]])
+        mutable.HashSet(1, 2).distinctBy(identity) should be(a[mutable.HashSet[_]])
+      }
+
+      it("should remove entries with duplicated projection") {
+        val abcde: Seq[(String, Int)] = Seq(
+          "a" -> 1,
+          "b" -> 2,
+          "c" -> 2,
+          "d" -> 3,
+          "e" -> 1
+        )
+
+        val abd = abcde.distinctBy { case (_, i) => i }
+
+        abd should be(a[Seq[_]])
+        abd should contain theSameElementsInOrderAs Seq(
+          "a" -> 1,
+          "b" -> 2,
+          "d" -> 3
+        )
+      }
+    }
+  }
+
+}

--- a/src/test/scala/za/co/absa/commons/parsers/UrisConnectionStringParserSpec.scala
+++ b/src/test/scala/za/co/absa/commons/parsers/UrisConnectionStringParserSpec.scala
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.commons.parsers
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class UrisConnectionStringParserSpec extends AnyWordSpec with Matchers {
+
+  "UrisConnectionStringParser::parse" should {
+    "parse a single base URL" when {
+      "it is http://" in {
+        val connectionString = "http://localhost:8080/rest_api"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List(connectionString))
+      }
+      "it is https://" in {
+        val connectionString = "https://localhost:8080/rest_api"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List(connectionString))
+      }
+      "it doesn't have a port" in {
+        val connectionString = "https://localhost/rest_api"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List(connectionString))
+      }
+      "it doesn't have a path" in {
+        val connectionString = "https://localhost"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List(connectionString))
+      }
+    }
+
+    "parse and expand unique hosts specified in a base URL" when {
+      "they are specified with or without port" in {
+        val connectionString = "http://host1:8080,host2/rest_api"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List("http://host1:8080/rest_api", "http://host2/rest_api"))
+      }
+      "there are duplicates" in {
+        val connectionString = "http://host1:8080,host1:8080/rest_api"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List("http://host1:8080/rest_api"))
+      }
+    }
+
+    "parse and expand unique multiple base URLs" when {
+      "they have single hosts specified" in {
+        val connectionString = "https://localhost:8080/rest_api;http://localhost:9000/rest_api"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List("https://localhost:8080/rest_api", "http://localhost:9000/rest_api"))
+      }
+      "they have multiple hosts specified" in {
+        val connectionString = "https://localhost:8080,host2:8080/rest_api;http://localhost:9000/rest_api"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(
+          List("https://localhost:8080/rest_api", "https://host2:8080/rest_api", "http://localhost:9000/rest_api")
+        )
+      }
+      "they have duplicates" in {
+        val connectionString = "https://localhost:8080,host2:8080/rest_api;https://localhost:8080/rest_api"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List("https://localhost:8080/rest_api", "https://host2:8080/rest_api"))
+      }
+    }
+
+    "drop any trailing whitespaces if present" when {
+      "parsing a single url" in {
+        val connectionString = "  http://localhost/rest_api/api "
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List("http://localhost/rest_api/api"))
+      }
+      "parsing a multiple urls" in {
+        val connectionString = "\thttp://localhost/rest_api/api  ;  https://localhost:8080/rest_api/api/ "
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List("http://localhost/rest_api/api", "https://localhost:8080/rest_api/api"))
+      }
+      "parsing a multiple urls with multiple hosts" in {
+        val connectionString = " http://localhost:8080,host2/rest_api/api\t;https://localhost/rest_api/api "
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(
+          List("http://localhost:8080/rest_api/api", "http://host2/rest_api/api", "https://localhost/rest_api/api")
+        )
+      }
+    }
+
+    "drop the ending slash if it is present at the end of the connection string" when {
+      "parsing a single url" in {
+        val connectionString = "http://localhost/rest_api/"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List("http://localhost/rest_api"))
+      }
+      "parsing a multiple urls" in {
+        val connectionString = "http://localhost/rest_api/;https://localhost:8080/rest_api/api/"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(List("http://localhost/rest_api", "https://localhost:8080/rest_api/api"))
+      }
+      "parsing a multiple urls with multiple hosts" in {
+        val connectionString = "http://localhost:8080,host2/rest_api/;https://localhost/rest_api/api/"
+
+        val result = UrisConnectionStringParser.parse(connectionString)
+
+        result should be(
+          List("http://localhost:8080/rest_api", "http://host2/rest_api", "https://localhost/rest_api/api")
+        )
+      }
+    }
+
+    "throw an exception" when {
+      "the connection string does not fit an http(s)://... pattern" in {
+        val connectionString = "qwe://localhost/rest_api/api"
+
+        val exception = intercept[IllegalArgumentException] {
+          UrisConnectionStringParser.parse(connectionString)
+        }
+
+        exception.getMessage should be("Malformed connection string")
+      }
+      "the connection string includes any url that does not fit an http(s)://... pattern" in {
+        val connectionString = "http://localhost:8080/rest_api/api;qwe://localhost/rest_api/api"
+
+        val exception = intercept[IllegalArgumentException] {
+          UrisConnectionStringParser.parse(connectionString)
+        }
+
+        exception.getMessage should be("Malformed connection string")
+      }
+      "the connection string includes whitespace characters in the hosts" in {
+        val connectionString = "http://localhost:8080, localhost:9000/rest_api/api"
+
+        val exception = intercept[IllegalArgumentException] {
+          UrisConnectionStringParser.parse(connectionString)
+        }
+
+        exception.getMessage should be("Malformed connection string")
+      }
+      "the connection string includes whitespace characters in the path" in {
+        val connectionString = "http://localhost:8080,localhost:9000/rest_api /api"
+
+        val exception = intercept[IllegalArgumentException] {
+          UrisConnectionStringParser.parse(connectionString)
+        }
+
+        exception.getMessage should be("Malformed connection string")
+      }
+    }
+
+    "keep the order of urls" when {
+      val expectedList = List(
+        "http://host1:8080/rest_api",
+        "http://host2:9000/rest_api",
+        "http://host3:8080/rest_api",
+        "http://host4:9000/rest_api",
+        "http://localhost:8080/rest_api",
+        "http://localhost:8090/rest_api"
+      )
+      "they are full fledged urls separated by semicolon" in {
+        val result = UrisConnectionStringParser
+          .parse(
+            "http://host1:8080/rest_api;http://host2:9000/rest_api;" +
+            "http://host3:8080/rest_api;http://host4:9000/rest_api;" +
+            "http://localhost:8080/rest_api;http://localhost:8090/rest_api"
+          )
+        result should be(expectedList)
+      }
+      "varied hosts separated by comma within one url" in {
+        val result = UrisConnectionStringParser
+          .parse(
+            "http://host1:8080,host2:9000,host3:8080,host4:9000,localhost:8080,localhost:8090/rest_api"
+          )
+        result should be(expectedList)
+      }
+    }
+  }
+}

--- a/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
+++ b/src/test/scala/za/co/absa/commons/reflect/ReflectionUtilsSpec.scala
@@ -195,6 +195,43 @@ class ReflectionUtilsSpec extends AnyFlatSpec with Matchers with MockitoSugar {
     ReflectionUtils.objectForName[AnyRef](MyObject.getClass.getName) should be theSameInstanceAs MyObject
   }
 
+  behavior of "objectForNameWithDescriptiveException()"
+
+  it should "return a 'static' Scala object instance by a full qualified name" in {
+    val result = ReflectionUtils.objectForNameWithDescriptiveException[AnyRef](MyObject.getClass.getName)
+
+    result should be theSameInstanceAs MyObject
+  }
+
+  it should "throw IllegalArgumentException with correct message if class doesn't exist" in {
+    val thrown = intercept[IllegalArgumentException] {
+      ReflectionUtils.objectForNameWithDescriptiveException[AnyRef]("doesntexist")
+    }
+
+    thrown.getMessage shouldEqual
+      "Class 'doesntexist' could not be found"
+  }
+
+  it should "throw IllegalArgumentException with correct message if class isn't an instance of provided type" in {
+    val thrown = intercept[IllegalArgumentException] {
+      ReflectionUtils.objectForNameWithDescriptiveException[Foo](MyObject.getClass.getName)
+    }
+
+    thrown.getMessage shouldEqual
+      s"Class '${MyObject.getClass.getName}' is not an instance of '${typeOf[Foo]}'"
+  }
+
+  it should "throw IllegalArgumentException with correct message if class isn't a singleton" in {
+    val barFullClassName = new Bar("", 0).getClass.getName
+
+    val thrown = intercept[IllegalArgumentException] {
+      ReflectionUtils.objectForNameWithDescriptiveException[Bar](barFullClassName)
+    }
+
+    thrown.getMessage shouldEqual
+      s"Class '$barFullClassName' is not a singleton"
+  }
+
   behavior of "caseClassCtorArgDefaultValue()"
 
   it should "return a case class constructor argument default value if declared" in {


### PR DESCRIPTION
#### Moved from Enceladus `utils` module:
- `implicits.OptionImplicits` -> `lang.extensions.OptionExtension`
- `implicits.StringImplicits` -> `lang.extensions.StringExtension`
- `general.Algorithms` -> `lang.extensions.SeqExtension`
- `general.ClassLoaderUtils.loadSingletonClassOfType` -> `reflect.ReflectionUtils.objectForNameWithDescriptiveException`
- `fs.LocalFsUtils` -> partially (without `getLocalTemporaryDirectory`, as this functionality is already in `io.TempDirectory`) `io.LocalFileSystemUtils`
- `[Menas/RestApi/Uris]ConnectionStringParser` -> `parsers.UrisConnectionStringParser`

#### On the fly [changes between Enceladus and commons]:
- added tests for `lang.extensions.OptionExtension`
- `nonEmpyOrElse` -> `nonEmptyOrElse` (fixed typo, `lang.extensions.StringExtension`)
- deduplicated code in `lang.extensions.SeqExtension` (in Enceladus these are 3 function with full body, here in commons there is one function with full body, and the other two are using the first one)
- renamed functions in `lang.extensions.SeqExtension` (in Enceladus `stableGroupBy...`, here in commons `groupConsecutiveBy...`)
- in `UrisConnectionStringParser.parse` removed deleting `/api` suffix as this is Enceladus-specific
- added tests for `reflect.ReflectionUtils.objectForNameWithDescriptiveException`
- changed implicit classed into implicit value classes

#### Restructured implicits in commons
Before this PR, there were two implicit files in `lang` - `CollectionImplicits` and `OptionImplicits`. However, these two have somewhat inconsistent convention of what should go in them. To solve that, I created subpackage `lang.extensions` and moved methods from previous implicit files there following convention:

- file name = object name = `TypeExtension` (extending capabilities of a given type)
- implicit class name = `TypeOps` (the same `Type` as in object name)

`CollectionImplicits` and `OptionImplicits` stay in the library for backwards compatibility, but are deprecated.

Also, implicits moved from Enceladus follow the new convention.

Closes #107 