### PR TITLE
issue #141 Migrate to a new Maven Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,13 +51,10 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>root-pom</artifactId>
-        <version>1.0.11</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
-        <scm.url>http://github.com/AbsaOSS/commons/tree/master</scm.url>
-        <scm.connection>scm:git:git://github.com/AbsaOSS/commons.git</scm.connection>
-        <scm.developerConnection>scm:git:ssh://github.com/AbsaOSS/commons.git</scm.developerConnection>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -99,7 +96,7 @@
     </properties>
 
     <scm>
-        <url>${scm.url}</url>
+        <url>http://github.com/AbsaOSS/commons</url>
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
         <tag>HEAD</tag>


### PR DESCRIPTION
fixes #19

- Upgrade `root-pom` to version 1.1.0
- Fix `scm.url` property
- Remove redundant `scm.connection` and `scm.developConnection` props as they are provided by the build agent