### PR TITLE
Generate Release Notes workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!-- What problem does it solve or what feature does it add? -->
+## Overview
+
+<!-- Summarize the key changes for release notes. -->
+## Release Notes
+- TBD: 1st item of release notes
+- TBD: 2nd item of release notes
+
+<!-- Add attached issue that this PR solves. -->
+## Related
+Closes #issue_number

--- a/.github/workflows/check_pr_release_notes.yml
+++ b/.github/workflows/check_pr_release_notes.yml
@@ -1,0 +1,26 @@
+name: Check PR Release Notes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    branches: [ master ]
+
+jobs:
+  check-release-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.14'
+
+      - name: Check presence of release notes in PR body
+        uses: AbsaOSS/release-notes-presence-check@8e586b26a5e27f899ee8590a5d988fd4780a3dbf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github-repository: ${{ github.repository }}
+          pr-number: ${{ github.event.number }}
+          title: "## [Rr]elease [Nn]otes"
+          skip-labels: 'no RN'
+          skip-placeholders: 'TBD'

--- a/.github/workflows/check_pr_release_notes.yml
+++ b/.github/workflows/check_pr_release_notes.yml
@@ -5,6 +5,10 @@ on:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches: [ master ]
 
+concurrency:
+  group: release-notes-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-release-notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -1,0 +1,109 @@
+name: Draft Release
+on:
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: 'Name of git tag to be created, and then draft release created. Syntax: "v[0-9]+.[0-9]+.[0-9]+".'
+        required: false
+      from-tag-name:
+        description: >-
+          Name of the git tag from which to detect changes from.
+          Default value: latest tag. Syntax: "v[0-9]+.[0-9]+.[0-9]+".
+        required: false
+
+jobs:
+  release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.14'
+
+      - name: Check format of received target tag
+        id: check-version-tag
+        uses: AbsaOSS/version-tag-check@4145e48bf3f77a5afff2ec9afdd8afb6b53bce34
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github-repository: ${{ github.repository }}
+          version-tag: ${{ github.event.inputs.tag-name }}
+
+      - name: Check format of received from tag
+        if: ${{ github.event.inputs.from-tag-name }}
+        id: check-version-from-tag
+        uses: AbsaOSS/version-tag-check@4145e48bf3f77a5afff2ec9afdd8afb6b53bce34
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github-repository: ${{ github.repository }}
+          version-tag: ${{ github.event.inputs.from-tag-name }}
+          should-exist: true
+
+      - name: Generate Release Notes
+        id: generate_release_notes
+        uses: AbsaOSS/generate-release-notes@da535383f54a6532adb84e88d3b6e5c7236132df
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release-notes-title: "## [Rr]elease [Nn]otes"
+          tag-name: ${{ github.event.inputs.tag-name }}
+          from-tag-name: ${{ github.event.inputs.from-tag-name }}
+          chapters: |
+            - { title: New Features 🎉, label: enhancement, order: 20 }
+            - { title: Bugfixes 🛠, label: bug, order: 30 }
+            - { title: Dependencies ⚙️, label: dependencies, order: 50 }
+            - { title: No entry 🚫, label: duplicate, hidden: true, order: 99 }
+          warnings: true
+          print-empty-chapters: false
+          row-format-issue: '{type}: {number} _{title}_ by {developers} in {pull-requests}'
+          row-format-pr: '{number} _{title}_ by {developers}'
+
+      - name: Create and push tag (standalone)
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const tag = core.getInput('tag-name')
+            const ref = `refs/tags/${tag}`;
+            const sha = context.sha; // The SHA of the commit to tag
+            const tagMessage = `${tag} released by GitHub Action`;
+
+            const tagObject = await github.rest.git.createTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: tag,
+              message: tagMessage,
+              object: sha,
+              type: 'commit',
+              tagger: {
+                name: context.actor,
+                email: `${context.actor}@users.noreply.github.com`,
+                date: new Date().toISOString()
+              }
+            });
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: ref,
+              sha: tagObject.data.sha
+            });
+
+            console.log(`Tag created: ${tag}`);
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag-name: ${{ github.event.inputs.tag-name }}
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ github.event.inputs.tag-name }}
+          body: ${{ steps.generate_release_notes.outputs.release-notes }}
+          tag_name: ${{ github.event.inputs.tag-name }}
+          draft: true
+          prerelease: false

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       tag-name:
         description: 'Name of git tag to be created, and then draft release created. Syntax: "v[0-9]+.[0-9]+.[0-9]+".'
-        required: false
+        required: true
       from-tag-name:
         description: >-
           Name of the git tag from which to detect changes from.
@@ -65,9 +65,11 @@ jobs:
 
       - name: Create and push tag (standalone)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag-name }}
         with:
           script: |
-            const tag = core.getInput('tag-name')
+            const tag = process.env.TAG_NAME;
             const ref = `refs/tags/${tag}`;
             const sha = context.sha; // The SHA of the commit to tag
             const tagMessage = `${tag} released by GitHub Action`;
@@ -95,7 +97,6 @@ jobs:
 
             console.log(`Tag created: ${tag}`);
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          tag-name: ${{ github.event.inputs.tag-name }}
 
       - name: Create draft release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -13,6 +13,8 @@ on:
 
 permissions:
   contents: write
+  issues: read
+  pull-requests: read
 
 jobs:
   release-draft:
@@ -74,23 +76,13 @@ jobs:
           script: |
             const tag = process.env.TAG_NAME;
             const ref = `refs/tags/${tag}`;
-            const sha = context.sha; // The SHA of the commit to tag
-            const tagMessage = `${tag} released by GitHub Action`;
-
-            const tagObject = await github.rest.git.createTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: tag,
-              message: tagMessage,
-              object: sha,
-              type: 'commit'
-            });
-
+            const sha = context.sha;
+            
             await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: ref,
-              sha: tagObject.data.sha
+              sha: sha
             });
 
             console.log(`Tag created: ${tag}`);

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -11,6 +11,9 @@ on:
           Default value: latest tag. Syntax: "v[0-9]+.[0-9]+.[0-9]+".
         required: false
 
+permissions:
+  contents: write
+
 jobs:
   release-draft:
     runs-on: ubuntu-latest
@@ -80,12 +83,7 @@ jobs:
               tag: tag,
               message: tagMessage,
               object: sha,
-              type: 'commit',
-              tagger: {
-                name: context.actor,
-                email: `${context.actor}@users.noreply.github.com`,
-                date: new Date().toISOString()
-              }
+              type: 'commit'
             });
 
             await github.rest.git.createRef({

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -65,9 +65,11 @@ jobs:
 
       - name: Create and push tag (standalone)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag-name }}
         with:
           script: |
-            const tag = core.getInput('tag-name')
+            const tag = process.env.TAG_NAME;
             const ref = `refs/tags/${tag}`;
             const sha = context.sha; // The SHA of the commit to tag
             const tagMessage = `${tag} released by GitHub Action`;
@@ -95,7 +97,6 @@ jobs:
 
             console.log(`Tag created: ${tag}`);
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          tag-name: ${{ github.event.inputs.tag-name }}
 
       - name: Create draft release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview
This pull request introduces new processes and templates to standardize and automate release note management in the repository. It adds a pull request template that prompts contributors to provide release notes, and sets up GitHub Actions workflows to check for release notes in PRs and to automate the drafting of releases, including tag validation and release note generation.

> The part of the solution was that I created a `no RN` label, that can turn off the RN checker, when the change does not need a release note (dependencies bump...)

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Adding Release Notes Generator workflow
- Adding Release Notes checker worfkflow
- Adding Pull Request template

<!-- Add attached issue that this PR solves. -->
## Related
Closes #145 
